### PR TITLE
TimeHelper

### DIFF
--- a/Izzy-Moonbot/Modules/DevModule.cs
+++ b/Izzy-Moonbot/Modules/DevModule.cs
@@ -279,7 +279,7 @@ public class DevModule : ModuleBase<SocketCommandContext>
                     var time = TimeHelper.Convert(timestring);
 
                     await ReplyAsync($"Successfully converted {timestring} to a DateTimeOffset.{Environment.NewLine}" +
-                                     $"DateTime: {time.Time.ToString()}{Environment.NewLine}" +
+                                     $"DateTime: <t:{time.Time.ToUnixTimeSeconds()}:F> (<t:{time.Time.ToUnixTimeSeconds()}:R>){Environment.NewLine}" +
                                      $"Repeats: {(time.Repeats ? "yes" : "no")}{Environment.NewLine}" +
                                      $"Repeats every: {time.RepeatType ?? "Doesn't repeat"}");
                 }


### PR DESCRIPTION
TimeHelper is a Helper type static class designed to aid in processing arbitrary user input into a valid DateTimeOffset. It supports relative times and absolute times.

Keywords can be used to make it process in a specific way, `at <time>` will provide today at `<time>`, `on`/`on the` will provide either a relative date based on the week (`on <weekday> at <time>`) or an absolute date (`on <date> at <time>`), `in` is relative (`in 5 hours`), and `every` causes the time to repeat. These keywords are not required as it is capable of processing times if they're not present.

The intention of this helper is to provide a way for users to input dates without having to deal with millisecond timestamps or worrying about having to have a very specific format.