### PR TITLE
#59: Don't print schedule task 'reasons' in mod log messages

### DIFF
--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -291,7 +291,7 @@ public class ScheduleService
         await _mod.AddRole(user, role.Id, reason);
         await _modLogging.CreateModLog(guild)
             .SetContent(
-                $"Gave <@&{role.Id}> to <@{user.Id}> (`{user.Id}`). {(reason != null ? $"Reason: {reason}." : "")}")
+                $"Gave <@&{role.Id}> to <@{user.Id}> (`{user.Id}`).")
             .SetFileLogContent(
                 $"Gave {role.Name} ({role.Id}) to {user.Username}#{user.Discriminator} ({user.Id}). {(reason != null ? $"Reason: {reason}." : "")}")
             .Send();
@@ -314,9 +314,9 @@ public class ScheduleService
         await _mod.RemoveRole(user, role.Id, reason);
         await _modLogging.CreateModLog(guild)
             .SetContent(
-                $"Removed <@&{role.Id}> from <@{user.Id}> (`{user.Id}`){(reason != null ? $" for {reason}" : "")}")
+                $"Removed <@&{role.Id}> from <@{user.Id}> (`{user.Id}`)")
             .SetFileLogContent(
-                $"Removed {role.Name} ({role.Id}) from {user.Username}#{user.Discriminator} ({user.Id}){(reason != null ? $" for {reason}" : "")}")
+                $"Removed {role.Name} ({role.Id}) from {user.Username}#{user.Discriminator} ({user.Id}). {(reason != null ? $"Reason: {reason}." : "")}")
             .Send();
     }
 


### PR DESCRIPTION
For now the internals of the scheduler are still up in the air, and I don't know if we want "reason" strings attached to every task in the long run, _but_ what's definitely true today is:
- task reasons are not designed to be user-facing output
- as long as tasks have reasons internally, there's no reason to exclude them from the dev/debug logs

So let's print them only to the log files.

The primary goal here is to make Izzy's remove role mod message less redundant, since the "reason" strings for those tasks today are just telling us how New Pony works:
![image](https://user-images.githubusercontent.com/5285357/201368511-a532bb6e-ad03-4f07-aa4b-9a7105109784.png)
I also tried to make the add role and remove role cases use consistent formatting.

Fixes #59 