### PR TITLE
Make the pressure embed correct by distinguishing between "old" pressure before and after decay is applied

### DIFF
--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -124,7 +124,7 @@ public class SpamService
         await FileHelper.SaveUsersAsync(_users);
 
         // Return new pressure
-        return currentPressure;
+        return _users[id].Pressure;
     }
 
     private async Task ProcessPressure(ulong id, SocketUserMessage message, SocketGuildUser user,


### PR DESCRIPTION
I believe this corrects the mistake you were explaining to me on Discord after my previous PR for #72.

This change to IncreasePressure might change the timestamp it saves to the user, but this looks to me like a drive-by bugfix. The existing code has IncreasePressure fetches the current time before calling GetAndDecayPressure, so when IncreasePressure sets the timestamp it was guaranteed to be using a value earlier or the same as what GetAndDecayPressure saved, which seems incorrect (albeit unlikely to matter).