### PR TITLE
Use a better delegate name and slightly more logging in the top-level worker code

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -151,7 +151,7 @@ namespace Izzy_Moonbot
 
         private async Task InstallCommandsAsync()
         {
-            _client.MessageReceived += HandleCommandAsync;
+            _client.MessageReceived += HandleMessageReceivedAsync;
             await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services.BuildServiceProvider());
         }
 
@@ -323,9 +323,8 @@ namespace Izzy_Moonbot
             });
         }
 
-        private async Task HandleCommandAsync(SocketMessage messageParam)
+        private async Task HandleMessageReceivedAsync(SocketMessage messageParam)
         {
-            //_logger.Log(LogLevel.Debug, $"{messageParam.CleanContent}; {messageParam.EditedTimestamp}");
             if (messageParam.Type != MessageType.Default && messageParam.Type != MessageType.Reply &&
                 messageParam.Type != MessageType.ThreadStarterMessage) return;
             SocketUserMessage message = messageParam as SocketUserMessage;
@@ -340,6 +339,8 @@ namespace Izzy_Moonbot
             if (message.HasCharPrefix(_config.Prefix, ref argPos) ||
                 message.Content.StartsWith($"<@{_client.CurrentUser.Id}>"))
             {
+                _logger.Log(LogLevel.Information, $"Received possible command: {messageParam.CleanContent}");
+
                 string parsedMessage;
                 var checkCommands = true;
                 if (message.Content.StartsWith($"<@{_client.CurrentUser.Id}>"))
@@ -393,7 +394,11 @@ namespace Izzy_Moonbot
                         command.Name == parsedMessage.Split(" ")[0] 
                         || command.Aliases.Contains(parsedMessage.Split(" ")[0]));
 
-                    if (!validCommand) return;
+                    if (!validCommand)
+                    {
+                        _logger.Log(LogLevel.Information, $"Ignoring message {messageParam.CleanContent} because it doesn't match any command or alias names");
+                        return;
+                    }
                 }
 
                 // Check for BotsAllowed attribute


### PR DESCRIPTION
When I was first getting Izzy set up locally, it was hard to tell if our Bot Testing messages were even reaching her because (after startup) she logs nothing by default. While it's probably a good idea not to log on _every_ message posted in Discord, I do think she should at least say something on messages that start with her command prefix.

Now typing `.asdf` in Bot Testing produces this by default:
![image](https://user-images.githubusercontent.com/5285357/202776170-dd04e2d1-bdc9-491d-9ca4-6842a70423ca.png)

Also, the `MessageReceived` delegate being named `HandleCommandAsync` made me assume that we'd already concluded this discord message was a _command_, but it turns out that determination comes later. So I corrected that name.
