### PR TITLE
move trigger word to a separate field

### DIFF
--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -56,8 +56,8 @@ public class FilterService
             .AddField("User", $"<@{context.User.Id}> (`{context.User.Id}`)", true)
             .AddField("Category", category, true)
             .AddField("Channel", $"<#{context.Channel.Id}>", true)
-            .AddField("Filtered message (trigger word in bold)",
-                $"{context.Message.CleanContent.Replace(word, $"**{word}**")}")
+            .AddField("Trigger Word", $"{word}")
+            .AddField("Filtered Message", $"{context.Message.CleanContent}")
             .WithTimestamp(onEdit ? (DateTimeOffset)context.Message.EditedTimestamp : context.Message.Timestamp);
 
         var actions = new List<string>();


### PR DESCRIPTION
Fixes #112, in which attempting to bold the "word" ended up breaking a url

Before:
![image](https://user-images.githubusercontent.com/5285357/203185978-499bb8b7-f820-4600-a22e-62edacad4a60.png)

After:
![image](https://user-images.githubusercontent.com/5285357/203186004-155faf72-ebec-4668-b8bd-10b78305e01b.png)
