### PR TITLE
cleanup unused IgnoreRoles and IgnoreChannels configs

### DIFF
--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -33,12 +33,6 @@ public class ConfigDescriber
         _config.Add("BatchLogsSendRate",
             new ConfigItem(ConfigItemType.Double, "The amount of seconds between each batch send.",
                 ConfigItemCategory.Core));
-        _config.Add("IgnoredChannels",
-            new ConfigItem(ConfigItemType.ChannelList, "A list of channels I will ignore commands from.",
-                ConfigItemCategory.Core));
-        _config.Add("IgnoredRoles",
-            new ConfigItem(ConfigItemType.RoleList, "A list of roles I will ignore commands from.",
-                ConfigItemCategory.Core));
         _config.Add("MentionResponseEnabled",
             new ConfigItem(ConfigItemType.Boolean, "Whether I will respond to someone mentioning me.",
                 ConfigItemCategory.Core));

--- a/Izzy-Moonbot/Settings/Config.cs
+++ b/Izzy-Moonbot/Settings/Config.cs
@@ -14,8 +14,6 @@ public class Config
         ThreadOnlyMode = true;
         BatchSendLogs = false;
         BatchLogsSendRate = 10;
-        IgnoredChannels = new HashSet<ulong>();
-        IgnoredRoles = new HashSet<ulong>();
         MentionResponseEnabled = false;
         MentionResponses = new List<string>();
         MentionResponseCooldown = 600;
@@ -85,8 +83,6 @@ public class Config
     public bool ThreadOnlyMode { get; set; }
     public bool BatchSendLogs { get; set; }
     public double BatchLogsSendRate { get; set; }
-    public HashSet<ulong> IgnoredChannels { get; set; }
-    public HashSet<ulong> IgnoredRoles { get; set; }
     public bool MentionResponseEnabled { get; set; }
     public List<string> MentionResponses { get; set; }
     public double MentionResponseCooldown { get; set; }


### PR DESCRIPTION
Closes #111

As pointed out in #111, these config values are currently unused. Other config values such as SpamIgnoredChannels, FilterIgnoredChannels and FilterBypassRoles already cover all the ignore behavior we want, so let's just delete them.