### PR TITLE
quick-and-dirty support for 3-4 digits in datetime arguments, until we can safely refactor the whole regex

### DIFF
--- a/Izzy-Moonbot/Helpers/TimeHelper.cs
+++ b/Izzy-Moonbot/Helpers/TimeHelper.cs
@@ -33,7 +33,7 @@ public static class TimeHelper
     public static TimeHelperResponse Convert(string input)
     {
         var timeFormatRegex = new Regex(
-            "^(?<query1>every |in |on |on the |at |)(?<weekday>monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tue|wed|thu|fri|sat|sun|)(?<query2>(?<date>a |\\d\\d |\\d |\\d\\dst |\\dst |\\d\\dnd |\\dnd |\\d\\drd |\\drd |\\d\\dth |\\dth |)| at )(of )?(?<month>years|year|months|month|days|day|weeks|week|days|day|hours|hour|minutes|minute|seconds|second|january|february|march|april|june|july|august|september|october|november|december|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|)(?<year> \\d\\d| \\d\\d\\d\\d|)(?<query3> at |)(?<time>\\d\\d:\\d\\d|\\d:\\d\\d|\\d\\d|\\d|\\dpm|\\d:\\d\\dpm|\\d\\d:\\d\\dpm|\\d\\dpm|\\dam|\\d:\\d\\dam|\\d\\dam|\\d\\d:\\d\\dam|)$",
+            "^(?<query1>every |in |on |on the |at |)(?<weekday>monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tue|wed|thu|fri|sat|sun|)(?<query2>(?<date>a |\\d\\d\\d\\d |\\d\\d\\d |\\d\\d |\\d |\\d\\dst |\\dst |\\d\\dnd |\\dnd |\\d\\drd |\\drd |\\d\\dth |\\dth |)| at )(of )?(?<month>years|year|months|month|days|day|weeks|week|days|day|hours|hour|minutes|minute|seconds|second|january|february|march|april|june|july|august|september|october|november|december|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|)(?<year> \\d\\d| \\d\\d\\d\\d|)(?<query3> at |)(?<time>\\d\\d:\\d\\d|\\d:\\d\\d|\\d\\d|\\d|\\dpm|\\d:\\d\\dpm|\\d\\d:\\d\\dpm|\\d\\dpm|\\dam|\\d:\\d\\dam|\\d\\dam|\\d\\d:\\d\\dam|)$",
             RegexOptions.IgnoreCase);
 
         var relativeMonths = new[]

--- a/Izzy-MoonbotTests/Service/TimeHelperTests.cs
+++ b/Izzy-MoonbotTests/Service/TimeHelperTests.cs
@@ -90,4 +90,21 @@ public class TimeHelperTests
             TimeHelper.Convert("every day at 12:30")
         );
     }
+
+    // TODO: refactor the impl regex so we can just accept arbitrarily long numbers without hacks
+    [TestMethod()]
+    public void Convert_MultipleDigitsTests()
+    {
+        AssertTimeHelperResponsesAreWithinOneSecond(
+            new TimeHelperResponse(DateTimeOffset.UtcNow.AddSeconds(123), false, null),
+            TimeHelper.Convert("in 123 seconds")
+        );
+
+        AssertTimeHelperResponsesAreWithinOneSecond(
+            new TimeHelperResponse(DateTimeOffset.UtcNow.AddSeconds(1234), false, null),
+            TimeHelper.Convert("in 1234 seconds")
+        );
+
+        Assert.ThrowsException<FormatException>(() => TimeHelper.Convert("12345"));
+    }
 }


### PR DESCRIPTION
Like the rest of https://github.com/Manechat/izzy-moonbot/milestone/5, I don't want to pursue a "proper" fix until we have way better test coverage, since parsing issues are especially prone to subtle regressions. But this is the only bug anyone found with "legitimate" .remindme usage today, and it's pretty easy to mitigate with only this targeted hack.