### PR TITLE
fix channel .config items by no longer relying on reference equality of Discord.NET objects

### DIFF
--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -232,7 +232,7 @@ public static class DiscordHelper
         if (context.IsPrivate) return 0;
 
         foreach (var channel in context.Guild.TextChannels)
-            if (channel.Name == channelName && channel.Users.Contains(izzyMoonbot))
+            if (channel.Name == channelName && channel.Users.Any(u => u.Id == izzyMoonbot.Id))
                 return channel.Id;
 
         return 0;
@@ -248,7 +248,7 @@ public static class DiscordHelper
         if (context.IsPrivate) return 0;
 
         foreach (var channel in context.Guild.TextChannels)
-            if (channel.Id == channelId && channel.Users.Contains(izzyMoonbot))
+            if (channel.Id == channelId && channel.Users.Any(u => u.Id == izzyMoonbot.Id))
                 return channel.Id;
 
         return 0;


### PR DESCRIPTION
Fixes https://github.com/Manechat/izzy-moonbot/issues/157

The root cause is that `channel.Users.Contains(izzyMoonbot)` relies on the fact that the `IUser` object returned by `ISocketMessageChannel.GetUserAsync()` is ___reference-identical___ to one of the `IReadOnlyCollection<SocketGuildUser>` elements returned by `SocketTextChannel.Users`.

In my opinion, this assumption is brittle at best, and the correct fix is simply to stop assuming it and compare ids instead (which I confirmed fixes the user-facing issue on Bot Testing). I also took a quick look at every Contains() call and == use in our codebase, and this seems to be the only place where we were comparing non-scalars anyway; everywhere similar already compares ids.

The other possible fix would be for the DiscordNetAdapters to mimic the same (undocumented, unsupported) reference equality behavior of the real Discord.NET library. This would most likely take the form of implementing an interning system for DiscordNetUserAdapter and the other DiscordNetAdapter objects. While it's generally desirable for test doubles and wrappers to mimic the real system as closely as is feasible, I hope we can agree that's not worth it.