### PR TITLE
correct formatting of roles/channels in Izzy output

### DIFF
--- a/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
+++ b/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
@@ -21,6 +21,11 @@ public class DiscordNetUserAdapter : IIzzyUser
     }
 
     public ulong Id { get => _user.Id; }
+
+    public override string? ToString()
+    {
+        return _user.ToString();
+    }
 }
 
 public class DiscordNetRoleAdapter : IIzzyRole
@@ -35,6 +40,11 @@ public class DiscordNetRoleAdapter : IIzzyRole
     public string Name { get => _role.Name; }
 
     public ulong Id { get => _role.Id; }
+
+    public override string? ToString()
+    {
+        return _role.ToString();
+    }
 }
 
 public class SocketUserMessageAdapter : IIzzyMessage
@@ -72,6 +82,7 @@ public class RestUserMessageAdapter : IIzzyMessage
     public ulong Id { get => _message.Id; }
     public string Content { get => _message.Content; }
     public IIzzyUser Author { get => new DiscordNetUserAdapter(_message.Author); }
+
     public async Task ReplyAsync(string message)
     {
         await _message.ReplyAsync(message);
@@ -97,6 +108,11 @@ public class SocketTextChannelAdapter : IIzzySocketTextChannel
 
     public IReadOnlyCollection<IIzzyUser> Users {
         get => _channel.Users.Select(user => new DiscordNetUserAdapter(user)).ToList();
+    }
+
+    public override string? ToString()
+    {
+        return _channel.ToString();
     }
 }
 
@@ -128,6 +144,11 @@ public class SocketMessageChannelAdapter : IIzzySocketMessageChannel
         var sentMesssage = await _channel.SendMessageAsync(message, allowedMentions: allowedMentions, components: components, options: options);
         return new RestUserMessageAdapter(sentMesssage);
     }
+
+    public override string? ToString()
+    {
+        return _channel.ToString();
+    }
 }
 
 public class SocketGuildChannelAdapter : IIzzySocketGuildChannel
@@ -142,6 +163,11 @@ public class SocketGuildChannelAdapter : IIzzySocketGuildChannel
     public ulong Id { get => _channel.Id; }
 
     public string Name { get => _channel.Name; }
+
+    public override string? ToString()
+    {
+        return _channel.ToString();
+    }
 }
 
 public class SocketGuildAdapter : IIzzyGuild

--- a/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
+++ b/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
@@ -15,7 +15,7 @@ public interface IIzzyRole
 {
     string Name { get; }
     ulong Id { get; }
-    string Mention { get => $"<@&{Name}>"; }
+    string Mention { get => $"<@&{Id}>"; }
 }
 
 public interface IIzzyMessage


### PR DESCRIPTION
So everything is technically _working_ on prod at the moment, but I noticed a rather obvious output formatting regression with roles/channels:
![image](https://user-images.githubusercontent.com/5285357/205095551-116dbafa-ed91-479e-9522-506fe5e8b445.png)
![image](https://user-images.githubusercontent.com/5285357/205095769-b6bad03c-6fca-4cdb-b656-e018bc7cf615.png)

As seems to be the theme this week, the root cause is simple mistakes in the Interfaces/Adapters used to enable testing. And also the fact that every type implementing `object` means that the whole "test double interface" thing can't detect that we're relying on `ToString()` output.

I'm thinking I should not allow myself to expand those Interfaces/Adapters again for at least a few days, if not a week, and also until after #161 is merged.