### PR TITLE
after deleting spam messages, also post and link to a bulk deletion log

### DIFF
--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Discord;
@@ -288,6 +290,8 @@ public class SpamService
         // Silence user, this also logs the action.
         await _mod.SilenceUser(user, $"Exceeded pressure max ({pressure}/{_config.SpamMaxPressure}) in <#{message.Channel.Id}>");
 
+        var bulkDeletionLog = new List<(DateTimeOffset, string)>();
+
         var alreadyDeletedMessages = 0;
         
         // Remove all messages considered part of spam.
@@ -295,10 +299,17 @@ public class SpamService
         {
             try
             {
-                var previousMessage = await context.Guild.GetTextChannel(previousMessageItem.ChannelId)
-                    .GetMessageAsync(previousMessageItem.Id);
-                if (previousMessage == null) alreadyDeletedMessages++;
-                else await previousMessage.DeleteAsync();
+                var channel = context.Guild.GetTextChannel(previousMessageItem.ChannelId);
+                var previousMessage = await channel.GetMessageAsync(previousMessageItem.Id);
+                if (previousMessage is not null)
+                {
+                    if (previousMessage.Content != "")
+                        bulkDeletionLog.Add((previousMessageItem.Timestamp,
+                            $"[{previousMessageItem.Timestamp}] in #{channel.Name}: {previousMessage.Content}"));
+                    await previousMessage.DeleteAsync();
+                }
+                else
+                    alreadyDeletedMessages++;
             }
             catch (HttpException exception)
             {
@@ -322,6 +333,35 @@ public class SpamService
             }
         }
 
+        string? bulkLogJumpUrl = null;
+        if (bulkDeletionLog.Count > 0)
+        {
+            var logChannelId = _config.LogChannel;
+            if (logChannelId == 0)
+                await _logger.Log("I couldn't post a bulk deletion log, because .config LogChannel hasn't been set.");
+            else
+            {
+                var logChannel = context.Guild.GetTextChannel(logChannelId);
+                if (logChannel is not null)
+                {
+                    await _logger.Log($"Assembling a bulk deletion log from the content of {bulkDeletionLog.Count} deleted messages");
+                    bulkDeletionLog.Sort((x, y) => x.Item1.CompareTo(y.Item1));
+                    var bulkDeletionLogString = string.Join(
+                        Environment.NewLine + Environment.NewLine,
+                        bulkDeletionLog.Select(logElement => logElement.Item2)
+                    );
+                    var s = new MemoryStream(Encoding.UTF8.GetBytes(bulkDeletionLogString));
+                    var fa = new FileAttachment(s, $"{context.User.Username}_{context.User.Id}_spam_bulk_deletion_log_{DateTimeOffset.UtcNow.ToString()}.txt");
+
+                    var spamBulkDeletionMessage = await logChannel.SendFileAsync(fa,
+                        $"Deleted recent messages from {context.User.Username} ({context.User.Id}) after they tripped spam detection, here's the bulk deletion log:");
+                    bulkLogJumpUrl = spamBulkDeletionMessage.GetJumpUrl();
+                }
+                else
+                    await _logger.Log("Something went wrong trying to access LogChannel.");
+            }
+        }
+
         if (alreadyAlerted) return;
         
         var embedBuilder = new EmbedBuilder()
@@ -331,6 +371,9 @@ public class SpamService
             .AddField("Channel", $"<#{context.Channel.Id}>", true)
             .AddField("Pressure", $"This user's last message raised their pressure from {oldPressureAfterDecay} to {pressure}, exceeding {_config.SpamMaxPressure}")
             .AddField("Breakdown of last message", $"{PonyReadableBreakdown(pressureBreakdown)}");
+
+        if (bulkLogJumpUrl is not null)
+            embedBuilder.AddField("Bulk Deletion Log", bulkLogJumpUrl);
 
         if (alreadyDeletedMessages != 0)
             embedBuilder.WithDescription(


### PR DESCRIPTION
Closes #139

Borrows from the .wipe implementation, though enough details changed that no code sharing was feasible in the end. In particular:
- a .wipe deletion is potentially multiple users in a single channel, while a spam deletion is a single user in potentially multiple channels
- for spam deletion, I want the mod log embed to link to the deletion log, because typically the mods have no idea what got deleted, unlike .wipe where the conversation being wiped is one they just read if not participated in

In Bot Testing, this produces:
![image](https://user-images.githubusercontent.com/5285357/205132364-8867d559-bee3-4701-a128-9b835dfeedc0.png)
and clicking that link successfully sends me to:
![image](https://user-images.githubusercontent.com/5285357/205132463-132fe2f2-f5ef-49d3-a7c4-100b7edff055.png)

