### PR TITLE
prevent MessageReceived handlers from 'blocking the gateway task' by making them async functions that 'leak' their tasks

### DIFF
--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -43,8 +43,12 @@ public class FilterService
     
     public void RegisterEvents(DiscordSocketClient client)
     {
-        client.MessageReceived += (message) => Task.Run(async () => { await ProcessMessage(message, client); });
-        client.MessageUpdated += (oldMessage, newMessage, channel) => Task.Run(async () => { await ProcessMessageUpdate(oldMessage, newMessage, channel, client); });
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        client.MessageReceived += async (message) => ProcessMessage(message, client);
+        client.MessageUpdated += async (oldMessage, newMessage, channel) => ProcessMessageUpdate(oldMessage, newMessage, channel, client);
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
     }
 
     private async Task LogFilterTrip(SocketCommandContext context, string word, string category,

--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -65,7 +65,11 @@ public class SpamService
     public void RegisterEvents(DiscordSocketClient client)
     {
         // Register MessageReceived event
-        client.MessageReceived += (message) => Task.Run(async () => { await MessageReceiveEvent(message, client); });
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        client.MessageReceived += async (message) => MessageReceiveEvent(message, client);
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
     }
 
     /// <summary>

--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -156,7 +156,12 @@ namespace Izzy_Moonbot
 
         private async Task InstallCommandsAsync()
         {
-            _client.MessageReceived += HandleMessageReceivedAsync;
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            _client.MessageReceived += async (message) => HandleMessageReceivedAsync(message);
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
             await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services.BuildServiceProvider());
         }
 


### PR DESCRIPTION
After a great deal of manual trial and error, I'm convinced this is the least nasty formulation of the event handlers that actually prevents the gateway block error:
> [2022-12-01 20:26:48 INF] A MessageReceived handler is blocking the gateway task.

An async function that awaits the inner function call definitely blocks the gateway. A regular function that calls Task.Run definitely blocks the gateway. An async function that awaits Task.Run definitely blocks the gateway. An async function that "leaks" Task.Run I think worked, but is just this PR with an extra step.

That it requires this much pragma spam is very unfortunate, and I strongly suspect we're missing something better. Thus, I'm applying this only to the MessageReceived handlers for today.

Also, this "solves" #165 if we assume the gateway block error is all we really care about. And maybe it is. But it's also clear from testing that Izzy gets rate limited _very_ quickly trying to delete spam, so we may want to do more to try and improve on this (EDIT: #73, #167). That said, several of my tests also just hung for several seconds with none of these errors, so the reality may very well be that Discord and the internet are slower than we'd like and sometimes spam is just messy no matter how you handle it.