### PR TITLE
Only ping mods on filter violations if the user got silenced

### DIFF
--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -66,7 +66,11 @@ public class FilterService
         if (actionsTaken.Contains("message"))
             actions.Add(
                 $":speech_balloon: - **I've sent a message in response.**");
-        if (actionsTaken.Contains("silence")) actions.Add(":mute: - **I've silenced the user.**");
+        if (actionsTaken.Contains("silence"))
+        {
+            actions.Add(":mute: - **I've silenced the user.**");
+            actions.Add(":exclamation: - **I've pinged all moderators.**");
+        }
 
         var roleIds = context.Guild.GetUser(context.User.Id).Roles.Select(role => role.Id).ToList();
         if (_config.FilterBypassRoles.Overlaps(roleIds))


### PR DESCRIPTION
Closes #170

I also found a few small bugs with FilterDevBypass, so I fixed those too.

After these tweaks, with FilterResponseSilence the mod channel receives:
![image](https://user-images.githubusercontent.com/5285357/205199293-0405a3c4-a74a-42ab-99a4-db50477c0256.png)

and without FilterResponseSilence, it receives:
![image](https://user-images.githubusercontent.com/5285357/205199339-21fd4447-2763-43e1-98ba-de926327f566.png)
