### PR TITLE
remove SafeMode config item

### DIFF
--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -18,10 +18,6 @@ public class ConfigDescriber
             new ConfigItem(ConfigItemType.Integer,
                 "How often, in milliseconds, I'll check scheduled jobs for execution.",
                 ConfigItemCategory.Core));
-        _config.Add("SafeMode",
-            new ConfigItem(ConfigItemType.Boolean,
-                "If set to true, I will not preform any moderation actions. This is best used when testing moderation functions in case of potentially broken code.",
-                ConfigItemCategory.Core));
         _config.Add("BatchSendLogs",
             new ConfigItem(ConfigItemType.Boolean,
                 "If set to true, I will batch send mod/action logs instead of sending them immediately. This is managed automatically by the Raid service to prevent me from being ratelimited.",

--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -90,11 +90,7 @@ public class FilterService
                 ":information_source: - **I've done nothing as this is one of my developers and `FilterDevBypass` is true.**");
         }
 
-        if (_config.SafeMode)
-            embedBuilder.AddField("How do I want to respond? (`SafeMode` is enabled)",
-                string.Join(Environment.NewLine, actions));
-        else
-            embedBuilder.AddField("What have I done in response?", string.Join(Environment.NewLine, actions));
+        embedBuilder.AddField("What have I done in response?", string.Join(Environment.NewLine, actions));
 
         var fileLogResponse = "Delete";
         if (actionsTaken.Contains("message")) fileLogResponse += ", Send Message";
@@ -142,10 +138,7 @@ public class FilterService
 
             if (messageResponse != null)
             {
-                if (_config.SafeMode)
-                    message = await context.Guild.GetTextChannel(_config.LogChannel).SendMessageAsync(
-                        $"<@{context.User.Id}> {messageResponse}{Environment.NewLine}{Environment.NewLine}*I am posting this message here as safe mode is enabled.*");
-                else message = await context.Channel.SendMessageAsync($"<@{context.User.Id}> {messageResponse}");
+                message = await context.Channel.SendMessageAsync($"<@{context.User.Id}> {messageResponse}");
                 actions.Add("message");
             }
 

--- a/Izzy-Moonbot/Service/ModService.cs
+++ b/Izzy-Moonbot/Service/ModService.cs
@@ -23,7 +23,7 @@ public class ModService
 
     public async Task KickUser(SocketGuildUser user, DateTimeOffset time, string? reason = null)
     {
-        if (!_config.SafeMode) await user.KickAsync(reason);
+        await user.KickAsync(reason);
     }
 
     public async Task KickUsers(IEnumerable<SocketGuildUser> users, string? reason = null)
@@ -32,7 +32,7 @@ public class ModService
 
         foreach (var user in users)
         {
-            if (!_config.SafeMode) await user.KickAsync(reason);
+            await user.KickAsync(reason);
         }
     }
 
@@ -40,13 +40,10 @@ public class ModService
     {
         if (_config.MemberRole == null) throw new TargetException("MemberRole config value is null (not set)");
         
-        if (!_config.SafeMode)
-        {
-            await user.RemoveRoleAsync((ulong) _config.MemberRole);
+        await user.RemoveRoleAsync((ulong) _config.MemberRole);
             
-            _users[user.Id].Silenced = true;
-            await FileHelper.SaveUsersAsync(_users);
-        }
+        _users[user.Id].Silenced = true;
+        await FileHelper.SaveUsersAsync(_users);
     }
 
     public async Task SilenceUsers(IEnumerable<SocketGuildUser> users, string? reason = null)
@@ -57,7 +54,6 @@ public class ModService
 
         foreach (var user in users)
         {
-            if (_config.SafeMode) continue;
             await user.RemoveRoleAsync((ulong)_config.MemberRole);
 
             _users[user.Id].Silenced = true;
@@ -67,7 +63,7 @@ public class ModService
 
     public async Task AddRole(SocketGuildUser user, ulong roleId, string? reason = null)
     {
-        if (!_config.SafeMode) await user.AddRoleAsync(roleId);
+        await user.AddRoleAsync(roleId);
     }
 
     public async Task AddRoleToUsers(IEnumerable<SocketGuildUser> users, ulong roleId, string? reason = null)
@@ -76,13 +72,13 @@ public class ModService
 
         foreach (var socketGuildUser in users)
         {
-            if (!_config.SafeMode) await socketGuildUser.AddRoleAsync(roleId);
+            await socketGuildUser.AddRoleAsync(roleId);
         }
     }
 
     public async Task RemoveRole(SocketGuildUser user, ulong roleId, string? reason = null)
     {
-        if (!_config.SafeMode) await user.RemoveRoleAsync(roleId);
+        await user.RemoveRoleAsync(roleId);
     }
 
     public async Task RemoveRoleFromUsers(IEnumerable<SocketGuildUser> users, ulong roleId, string? reason = null)
@@ -91,13 +87,13 @@ public class ModService
 
         foreach (var socketGuildUser in users)
         {
-            if (!_config.SafeMode) await socketGuildUser.RemoveRoleAsync(roleId);
+            await socketGuildUser.RemoveRoleAsync(roleId);
         }
     }
 
     public async Task AddRoles(SocketGuildUser user, IEnumerable<ulong> roles, string? reason = null)
     {
-        if (!_config.SafeMode) await user.AddRolesAsync(roles);
+        await user.AddRolesAsync(roles);
     }
 
     public async Task AddRolesToUsers(IEnumerable<SocketGuildUser> users, IEnumerable<ulong> roles, string? reason = null)
@@ -107,14 +103,14 @@ public class ModService
 
         foreach (var socketGuildUser in users)
         {
-            if (!_config.SafeMode) await socketGuildUser.AddRolesAsync(roles);
+            await socketGuildUser.AddRolesAsync(roles);
         }
     }
 
     public async Task RemoveRoles(SocketGuildUser user, IEnumerable<ulong> roles, string? reason = null)
     {
         if (!roles.Any()) throw new NullReferenceException("roles must have role ids in them");
-        if (!_config.SafeMode) await user.RemoveRolesAsync(roles);
+        await user.RemoveRolesAsync(roles);
     }
 
     public async Task RemoveRolesFromUsers(IEnumerable<SocketGuildUser> users, IEnumerable<ulong> roles, string? reason = null)
@@ -124,7 +120,7 @@ public class ModService
 
         foreach (var socketGuildUser in users)
         {
-            if (!_config.SafeMode) await socketGuildUser.RemoveRolesAsync(roles);
+            await socketGuildUser.RemoveRolesAsync(roles);
         }
     }
 }

--- a/Izzy-Moonbot/Settings/Config.cs
+++ b/Izzy-Moonbot/Settings/Config.cs
@@ -16,7 +16,6 @@ public class Config
         // Core settings
         Prefix = '.';
         UnicycleInterval = 100;
-        SafeMode = true;
         BatchSendLogs = false;
         BatchLogsSendRate = 10;
         MentionResponseEnabled = false;
@@ -82,7 +81,6 @@ public class Config
     // Core settings
     public char Prefix { get; set; }
     public int UnicycleInterval { get; set; }
-    public bool SafeMode { get; set; }
     public bool BatchSendLogs { get; set; }
     public double BatchLogsSendRate { get; set; }
     public bool MentionResponseEnabled { get; set; }

--- a/Izzy-MoonbotTests/Service/ConfigModuleTests.cs
+++ b/Izzy-MoonbotTests/Service/ConfigModuleTests.cs
@@ -523,13 +523,6 @@ public class ConfigModuleTests
         Assert.AreEqual(cfg.UnicycleInterval, 42);
         Assert.AreEqual("I've set `UnicycleInterval` to the following content: 42", generalChannel.Messages.Last().Content);
 
-        // post ".config SafeMode false"
-        Assert.AreEqual(cfg.SafeMode, true);
-        context = client.AddMessage(guild.Id, generalChannel.Id, sunny.Id, ".config SafeMode false");
-        await ConfigModule.TestableConfigCommandAsync(context, cfg, cd, "SafeMode", "false");
-        Assert.AreEqual(cfg.SafeMode, false);
-        Assert.AreEqual("I've set `SafeMode` to the following content: False", generalChannel.Messages.Last().Content);
-
         // post ".config BatchSendLogs true"
         Assert.AreEqual(cfg.BatchSendLogs, false);
         context = client.AddMessage(guild.Id, generalChannel.Id, sunny.Id, ".config BatchSendLogs true");
@@ -892,7 +885,7 @@ public class ConfigModuleTests
         // Ensure we can't forget to keep this test up to date
         var configPropsCount = typeof(Config).GetProperties().Length;
 
-        Assert.AreEqual(51, configPropsCount,
+        Assert.AreEqual(50, configPropsCount,
             $"{Environment.NewLine}If you just added or removed a config item, then this test is probably out of date");
 
         Assert.AreEqual(configPropsCount * 2, generalChannel.Messages.Count(),


### PR DESCRIPTION
Part of #123

Since this touches several sensitive methods, and I've been not so great at introducing bugs lately, let's be paranoid and give it its own tiny PR.

Also manually tested with:
- my alt tripping the filter, checking it got silenced
- using .assignrole on my alt, with and without a duration
- made my alt leave and rejoin the test serve, checking it got new-member-role auto-assigned
- running .config SafeMode and .config core

Which I believe hits every non-dead codepath edited here (did you know half of ModService's methods are unused? 😅), except SilenceUsers (plural) which is only used during raids.