### PR TITLE
Move `CurrentRaidMode`, `ManualRaidSilence`, and `CurrentBooruFeaturedImage` to non-volatile storage.

### DIFF
--- a/Izzy-Moonbot/Modules/RaidModule.cs
+++ b/Izzy-Moonbot/Modules/RaidModule.cs
@@ -20,15 +20,17 @@ public class RaidModule : ModuleBase<SocketCommandContext>
     private readonly ScheduleService _scheduleService;
     private readonly Config _config;
     private readonly State _state;
+    private readonly GeneralStorage _generalStorage;
 
     public RaidModule(Config config, RaidService raidService, State state,
-        ScheduleService scheduleService, ModService modService)
+        ScheduleService scheduleService, ModService modService, GeneralStorage generalStorage)
     {
         _config = config;
         _raidService = raidService;
         _state = state;
         _scheduleService = scheduleService;
         _modService = modService;
+        _generalStorage = generalStorage;
     }
 
     [Command("ass")]
@@ -38,7 +40,7 @@ public class RaidModule : ModuleBase<SocketCommandContext>
     [DevCommand(Group = "Permissions")]
     public async Task AssAsync()
     {
-        if (_state.CurrentRaidMode == RaidMode.None)
+        if (_generalStorage.CurrentRaidMode == RaidMode.None)
         {
             await ReplyAsync("There doesn't seem to be any raids going on...");
             return;
@@ -56,7 +58,7 @@ public class RaidModule : ModuleBase<SocketCommandContext>
     [DevCommand(Group = "Permissions")]
     public async Task AssOffAsync()
     {
-        if (_state.CurrentRaidMode == RaidMode.None)
+        if (_generalStorage.CurrentRaidMode == RaidMode.None)
         {
             await ReplyAsync("There doesn't seem to be any raids going on...");
             return;
@@ -74,7 +76,7 @@ public class RaidModule : ModuleBase<SocketCommandContext>
     [DevCommand(Group = "Permissions")]
     public async Task GetRaidAsync()
     {
-        if (_state.CurrentRaidMode == RaidMode.None)
+        if (_generalStorage.CurrentRaidMode == RaidMode.None)
         {
             await ReplyAsync("There doesn't seem to be any raids going on...");
             return;
@@ -98,7 +100,7 @@ public class RaidModule : ModuleBase<SocketCommandContext>
     [DevCommand(Group = "Permissions")]
     public async Task BanRaidAsync()
     {
-        if (_state.CurrentRaidMode == RaidMode.NONE)
+        if (_generalStorage.CurrentRaidMode == RaidMode.NONE)
         {
             await ReplyAsync("There doesn't seem to be any raids going on...", messageReference: new Discord.MessageReference(Context.Message.Id, Context.Channel.Id, Context.Guild.Id));
             return;

--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -24,20 +24,20 @@ public class ScheduleService
     private readonly LoggingService _logger;
     private readonly ModService _mod;
     private readonly ModLoggingService _modLogging;
-    private State _state;
+    private GeneralStorage _generalStorage;
 
     private readonly List<ScheduledJob> _scheduledJobs;
 
     private bool _alreadyInitiated;
 
-    public ScheduleService(Config config, ModService mod, ModLoggingService modLogging, LoggingService logger, State state,
+    public ScheduleService(Config config, ModService mod, ModLoggingService modLogging, LoggingService logger, GeneralStorage generalStorage,
         List<ScheduledJob> scheduledJobs)
     {
         _config = config;
         _logger = logger;
         _mod = mod;
         _modLogging = modLogging;
-        _state = state;
+        _generalStorage = generalStorage;
         _scheduledJobs = scheduledJobs;
     }
 
@@ -458,19 +458,21 @@ public class ScheduleService
             {
                 var image = await BooruHelper.GetFeaturedImage();
 
-                if (_state.CurrentBooruFeaturedImage != null)
+                if (_generalStorage.CurrentBooruFeaturedImage != null)
                 {
-                    if (image.Id == _state.CurrentBooruFeaturedImage.Id)
+                    if (image.Id == _generalStorage.CurrentBooruFeaturedImage.Id)
                     {
                         // Update the cache in case of change, but return
-                        _state.CurrentBooruFeaturedImage =
+                        _generalStorage.CurrentBooruFeaturedImage =
                             image; // Cache to not anger CULTPONY or Twilight (API docs say to cache)
+                        await FileHelper.SaveGeneralStorageAsync(_generalStorage);
                         return;
                     }
                 }
 
-                _state.CurrentBooruFeaturedImage =
+                _generalStorage.CurrentBooruFeaturedImage =
                     image; // Cache to not anger CULTPONY or Twilight (API docs say to cache)
+                await FileHelper.SaveGeneralStorageAsync(_generalStorage);
 
                 // Don't check the images if they're not ready yet!
                 if (!image.ThumbnailsGenerated || image.Representations == null)

--- a/Izzy-Moonbot/Settings/GeneralStorage.cs
+++ b/Izzy-Moonbot/Settings/GeneralStorage.cs
@@ -1,3 +1,6 @@
+using Izzy_Moonbot.Helpers;
+using Izzy_Moonbot.Service;
+
 namespace Izzy_Moonbot.Settings;
 
 // General misc storage
@@ -7,5 +10,18 @@ public class GeneralStorage
 {
     public GeneralStorage()
     {
+        // Antiraid
+        CurrentRaidMode = RaidMode.None;
+        ManualRaidSilence = false;
+        
+        // Banner management
+        CurrentBooruFeaturedImage = null;
     }
+    
+    // Antiraid
+    public RaidMode CurrentRaidMode { get; set; }
+    public bool ManualRaidSilence { get; set; }
+    
+    // Banner management
+    public BooruImage? CurrentBooruFeaturedImage { get; set; }
 }

--- a/Izzy-Moonbot/Settings/State.cs
+++ b/Izzy-Moonbot/Settings/State.cs
@@ -10,17 +10,11 @@ namespace Izzy_Moonbot.Settings;
 public class State
 {
     public int CurrentLargeJoinCount = 0;
-    public RaidMode CurrentRaidMode = RaidMode.None;
     public int CurrentSmallJoinCount = 0;
 
     // AdminModule
     public DateTimeOffset LastMentionResponse = DateTimeOffset.MinValue;
 
-    public bool ManualRaidSilence = false;
-
     // RaidService
     public List<ulong> RecentJoins = new();
-    
-    // Banner management
-    public BooruImage? CurrentBooruFeaturedImage = null;
 }


### PR DESCRIPTION
This moves 3 critical state objects from State to GeneralStorage so that they are properly saved. 