### PR TITLE
cleanup unreleased .banraid command

### DIFF
--- a/Izzy-Moonbot/Modules/RaidModule.cs
+++ b/Izzy-Moonbot/Modules/RaidModule.cs
@@ -92,29 +92,4 @@ public class RaidModule : ModuleBase<SocketCommandContext>
         await ReplyAsync(
             $"I consider the following users as part of the current raid.{Environment.NewLine}```{Environment.NewLine}{string.Join(", ", potentialRaiders)}{Environment.NewLine}```");
     }
-
-    /*[Command("banraid")]
-    [Summary("Ban all those considered part of the current raid. **ONLY USE AS LAST RESORT**")]
-    [RequireContext(ContextType.Guild)]
-    [ModCommand(Group = "Permissions")]
-    [DevCommand(Group = "Permissions")]
-    public async Task BanRaidAsync()
-    {
-        if (_generalStorage.CurrentRaidMode == RaidMode.NONE)
-        {
-            await ReplyAsync("There doesn't seem to be any raids going on...", messageReference: new Discord.MessageReference(Context.Message.Id, Context.Channel.Id, Context.Guild.Id));
-            return;
-        }
-
-        List<string> potentialRaiders = new List<string>();
-
-        _raidService.GetRecentJoins(Context).ForEach((user) =>
-        {
-            potentialRaiders.Add($"{user.Username}#{user.Discriminator}");
-
-            Context.Guild.AddBanAsync(user, pruneDays: 7, reason: "Ban Raid Command");
-        });
-
-        await ReplyAsync($"I consider the following users as part of the current raid and thus have been banned.{Environment.NewLine}```{Environment.NewLine}{string.Join(", ", potentialRaiders)}{Environment.NewLine}```", messageReference: new Discord.MessageReference(Context.Message.Id, Context.Channel.Id, Context.Guild.Id));
-    }*/
 }

--- a/Izzy-Moonbot/Service/RaidService.cs
+++ b/Izzy-Moonbot/Service/RaidService.cs
@@ -223,8 +223,7 @@ public class RaidService
                     $"Possible commands for this scenario are:{Environment.NewLine}" +
                     $"`{_config.Prefix}ass` - Enable automatically silencing new joins *and* autosilence those considered part of the raid (those who joined within {_config.RecentJoinDecay} (`RecentJoinDecay`) seconds).{Environment.NewLine}" +
                     $"`{_config.Prefix}assoff` - Disable automatically silencing new joins and resets the raid level back to 'no raid'. This will **not** unsilence those considered part of the raid.{Environment.NewLine}" +
-                    $"`{_config.Prefix}getraid` - Returns a list of those who are considered part of the raid by Izzy. (those who joined {_config.RecentJoinDecay} (`RecentJoinDecay`) seconds before the raid began).{Environment.NewLine}" +
-                    $"`{_config.Prefix}banraid` - Bans everyone considered to be part of the raid. **This should be a last measure if Izzy becomes ratelimited while trying to deal with the raid. Use `getraid` to see who would be banned.**")
+                    $"`{_config.Prefix}getraid` - Returns a list of those who are considered part of the raid by Izzy. (those who joined {_config.RecentJoinDecay} (`RecentJoinDecay`) seconds before the raid began).")
                 .SetFileLogContent($"Bing-bong! Possible raid detected! ({_config.SmallRaidSize} (`SmallRaidSize`) users joined within {_config.SmallRaidTime} (`SmallRaidTime`) seconds.){Environment.NewLine}" +
                                    $"{string.Join($"{Environment.NewLine}", potentialRaiders)}{Environment.NewLine}")
                 .Send();
@@ -283,8 +282,7 @@ public class RaidService
                         $"{string.Join($"{Environment.NewLine}", potentialRaiders)}{Environment.NewLine}{Environment.NewLine}" +
                         $"Possible commands for this scenario are:{Environment.NewLine}" +
                         $"`{_config.Prefix}assoff` - Disable automatically silencing new joins and resets the raid level back to 'no raid'.. This will **not** unsilence those considered part of the raid.{Environment.NewLine}" +
-                        $"`{_config.Prefix}getraid` - Returns a list of those who are considered part of the raid by Izzy. (those who joined within {_config.RecentJoinDecay} (`RecentJoinDecay`) seconds).{Environment.NewLine}" +
-                        $"`{_config.Prefix}banraid` - Bans everyone considered to be part of the raid. **This should be a last measure if Izzy becomes ratelimited while trying to deal with the raid. Use `getraid` to see who would be banned.**")
+                        $"`{_config.Prefix}getraid` - Returns a list of those who are considered part of the raid by Izzy. (those who joined within {_config.RecentJoinDecay} (`RecentJoinDecay`) seconds).")
                     .SetFileLogContent($"Bing-bong! Raid detected! ({_config.LargeRaidSize} (`LargeRaidSize`) users joined within {_config.LargeRaidTime} (`LargeRaidTime`) seconds.){Environment.NewLine}" +
                                        $"I have automatically silenced all the members below members and enabled autosilencing users on join.{Environment.NewLine}" +
                                        $"{string.Join($"{Environment.NewLine}", potentialRaiders)}{Environment.NewLine}")


### PR DESCRIPTION
I just noticed during today's raid that Izzy tells us about a .banraid command, but in the RaidModule .banraid is completely commented out, so (I assume) nothing would happen if someone actually tried to use it.

Unless and until one of us feels like making it real and properly testing it, this incorrect instruction and commented-out code are better off deleted.