### PR TITLE
unbreak .lq without args by adding more null checks in DiscordNetAdapters

### DIFF
--- a/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
+++ b/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
@@ -246,10 +246,26 @@ public class SocketGuildAdapter : IIzzyGuild
         get => _guild.Roles.Select(role => new DiscordNetRoleAdapter(role)).ToList();
     }
 
-    public IIzzyGuildUser? GetUser(ulong userId) => new DiscordNetGuildUserAdapter(_guild.GetUser(userId));
-    public IIzzyRole? GetRole(ulong roleId) => new DiscordNetRoleAdapter(_guild.GetRole(roleId));
-    public IIzzySocketGuildChannel? GetChannel(ulong channelId) => new SocketGuildChannelAdapter(_guild.GetChannel(channelId));
-    public IIzzySocketTextChannel? GetTextChannel(ulong channelId) => new SocketTextChannelAdapter(_guild.GetTextChannel(channelId));
+    public IIzzyGuildUser? GetUser(ulong userId)
+    {
+        var user = _guild.GetUser(userId);
+        return user is null ? null : new DiscordNetGuildUserAdapter(user);
+    }
+    public IIzzyRole? GetRole(ulong roleId)
+    {
+        var role = _guild.GetRole(roleId);
+        return role is null ? null : new DiscordNetRoleAdapter(role);
+    }
+    public IIzzySocketGuildChannel? GetChannel(ulong channelId)
+    {
+        var channel = _guild.GetChannel(channelId);
+        return channel is null ? null : new SocketGuildChannelAdapter(channel);
+    }
+    public IIzzySocketTextChannel? GetTextChannel(ulong channelId)
+    {
+        var textChannel = _guild.GetTextChannel(channelId);
+        return textChannel is null ? null : new SocketTextChannelAdapter(textChannel);
+    }
 }
 
 public class IdHaver : IIzzyHasId

--- a/Izzy-MoonbotTests/Service/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Service/QuoteModuleTests.cs
@@ -124,6 +124,32 @@ public class QuoteModuleTests
     }
 
     [TestMethod()]
+    public async Task ListQuotes_ExternalUsers_Tests()
+    {
+        var (cfg, _, (izzy, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();
+        DiscordHelper.DefaultGuildId = guild.Id;
+
+        // Test with a quote from a user id that is no longer in our guild
+        var quotes = new QuoteStorage();
+        quotes.Quotes.Add("1234", new List<string> { "minty was here" });
+
+        var userinfo = new Dictionary<ulong, User>();
+        var qs = new QuoteService(quotes, userinfo);
+        var qm = new QuotesSubmodule(cfg, qs);
+
+        var context = client.AddMessage(guild.Id, generalChannel.Id, sunny.Id, ".listquotes");
+        await qm.TestableListQuotesCommandAsync(context, "");
+
+        var description = generalChannel.Messages.Last().Content;
+        StringAssert.Contains(description, "Here's a list of");
+        StringAssert.Contains(description, $"```{Environment.NewLine}" +
+            $"1234 {Environment.NewLine}" +
+            $"```{Environment.NewLine}");
+        StringAssert.Contains(description, "Run `.quote <user/category>`");
+        StringAssert.Contains(description, "Run `.quote`");
+    }
+
+    [TestMethod()]
     public async Task AddAndRemoveQuotes_Tests()
     {
         var (cfg, _, (_, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();


### PR DESCRIPTION
The test in this PR doesn't catch this particular bug, since by design DiscordNetAdapters is the file full of code the tests can't hit, but I already wrote it so why not.