### PR TITLE
do the CI build+test in Release mode

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Build
       run: dotnet build -c Release --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test -c Release --no-build --verbosity normal


### PR DESCRIPTION
Today's pile of release issues included a release-only build failure. Although we should minimize #if DEBUG in general for this exact reason, CI would also do a better job of telling us if "the build really fails" if it ran in release mode. We're already building in debug mode constantly on our local machines, so making CI do both configurations feels like overkill.

I also buy https://stackoverflow.com/questions/54436557/should-tests-run-in-debug-or-release-configuration-in-dotnet-core 's arguments that C# testing is generally better done with release builds anyway.