### PR TITLE
reimplement TrimDiscordWhitespace with regexes and handle <:name:id> blanks

### DIFF
--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -10,6 +10,7 @@ using Izzy_Moonbot.Adapters;
 using Microsoft.Extensions.Configuration;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Izzy_Moonbot.Helpers;
 
@@ -357,31 +358,24 @@ public static class DiscordHelper
     }
 
     // Where "Discord whitespace" refers to Char.IsWhiteSpace as well as the ":blank:" emoji
-    public static string TrimDiscordWhitespace(string s)
+    public static string TrimDiscordWhitespace(string wholeString)
     {
-        var blankEmoji = ":blank:";
+        var singleCharacterOrEmojiOfWhitespace = new List<string> {
+            @"\s",
+            @":blank:",
+            @"<:blank:[0-9]+>"
+        };
+        var runOfDiscordWhitespace = $"({ string.Join("|", singleCharacterOrEmojiOfWhitespace)})+";
 
-        var substringStartIndex = 0;
-        while ((s.Length >= (substringStartIndex + 1) && Char.IsWhiteSpace(s[substringStartIndex])) ||
-               (s.Length >= (substringStartIndex + blankEmoji.Length) && s.Substring(substringStartIndex, blankEmoji.Length) == blankEmoji))
-        {
-            if (Char.IsWhiteSpace(s[substringStartIndex])) substringStartIndex += 1;
-            else substringStartIndex += blankEmoji.Length;
+        var leadingWhitespaceRegex = new Regex($"^{runOfDiscordWhitespace}");
+        var trailingWhitespaceRegex = new Regex($"{runOfDiscordWhitespace}$");
 
-            if (substringStartIndex == s.Length) return "";
-        }
+        var s = wholeString;
+        if (leadingWhitespaceRegex.Matches(s).Any())
+            s = leadingWhitespaceRegex.Replace(s, "");
+        if (trailingWhitespaceRegex.Matches(s).Any())
+            s = trailingWhitespaceRegex.Replace(s, "");
 
-        var substringEndIndex = s.Length - 1;
-        if (s.Length > 0)
-        {
-            while (Char.IsWhiteSpace(s[substringEndIndex]) ||
-                   (substringEndIndex >= (blankEmoji.Length - 1) && s.Substring(substringEndIndex - blankEmoji.Length + 1, blankEmoji.Length) == blankEmoji))
-            {
-                if (Char.IsWhiteSpace(s[substringEndIndex])) substringEndIndex -= 1;
-                else substringEndIndex -= blankEmoji.Length;
-            }
-        }
-
-        return s.Substring(substringStartIndex, substringEndIndex - substringStartIndex + 1);
+        return s;
     }
 }

--- a/Izzy-MoonbotTests/Service/DiscordHelperTests.cs
+++ b/Izzy-MoonbotTests/Service/DiscordHelperTests.cs
@@ -209,5 +209,18 @@ public class DiscordHelperTests
         Assert.AreEqual("Izzy", TrimDiscordWhitespace("\n:blank:Izzy\n:blank:"));
 
         Assert.AreEqual("IzzyIzzyIzzy", TrimDiscordWhitespace("\n:blank: \n:blank: \nIzzyIzzyIzzy\n"));
+
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("<:blank:833008517257756752>Izzy"));
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("Izzy<:blank:833008517257756752>"));
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("<:blank:833008517257756752>Izzy<:blank:833008517257756752>"));
+
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("\n<:blank:833008517257756752>Izzy"));
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("<:blank:833008517257756752>\nIzzy"));
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("Izzy\n<:blank:833008517257756752>"));
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("Izzy<:blank:833008517257756752>\n"));
+        Assert.AreEqual("Izzy", TrimDiscordWhitespace("\n<:blank:833008517257756752>Izzy\n<:blank:833008517257756752>"));
+
+        Assert.AreEqual("IzzyIzzyIzzy", TrimDiscordWhitespace("\n<:blank:833008517257756752> \n<:blank:833008517257756752> \nIzzyIzzyIzzy\n"));
+
     }
 }


### PR DESCRIPTION
I'm _pretty sure_ it works this time:

![image](https://user-images.githubusercontent.com/5285357/206571620-d274c2f4-b1e6-4834-93a3-72b92fe13cfa.png)
(Cloud probably knows this but for the record: this test was done by quickly hardcoding channel/message ids, since our testing server has no rules with :blank:s in them)

And in retrospect learning how to properly do C# regexes would've made even the first version of this function much easier to read and write.