### PR TITLE
add involved users to .wipe's LogChannel message

### DIFF
--- a/Izzy-Moonbot/Modules/AdminModule.cs
+++ b/Izzy-Moonbot/Modules/AdminModule.cs
@@ -832,7 +832,7 @@ public class AdminModule : ModuleBase<SocketCommandContext>
 
         // We've seen GetMessagesAsync return the messages in both chronological and reverse chronological order,
         // so we need to remember the message creation times in order to do our own sorting at the end.
-        var bulkDeletionLog = new List<(DateTimeOffset, string)>();
+        var bulkDeletionLog = new List<(DateTimeOffset, string, string)>();
 
         // Because snowflake ids correspond to datetime moments, we can use a snowflake to directly ask for all messages
         // after a certain moment, even if that snowflake is not the actual id of any message in the channel.
@@ -843,7 +843,11 @@ public class AdminModule : ModuleBase<SocketCommandContext>
             foreach (var message in recentMessages)
             {
                 messageIdsToDelete.Add(message.Id);
-                bulkDeletionLog.Add((message.CreatedAt, $"[{message.CreatedAt}] {message.Author.Username}: {message.Content}"));
+                bulkDeletionLog.Add((
+                    message.CreatedAt,
+                    $"{message.Author.Username} ({message.Author.Id})",
+                    $"[{message.CreatedAt}] {message.Author.Username}: {message.Content}"
+                ));
             }
         }
 
@@ -877,13 +881,17 @@ public class AdminModule : ModuleBase<SocketCommandContext>
         {
             await _logger.Log($"Assembling a bulk deletion log from the content of {messagesToDeleteCount} deleted messages");
             bulkDeletionLog.Sort((x, y) => x.Item1.CompareTo(y.Item1));
+
             var bulkDeletionLogString = string.Join(
                 Environment.NewLine + Environment.NewLine,
-                bulkDeletionLog.Select(logElement => logElement.Item2)
+                bulkDeletionLog.Select(logElement => logElement.Item3)
             );
+
+            var involvedUserDescriptions = string.Join(", ", bulkDeletionLog.Select(logElement => logElement.Item2).ToHashSet());
+
             var s = new MemoryStream(Encoding.UTF8.GetBytes(bulkDeletionLogString));
             var fa = new FileAttachment(s, $"{channel.Name}_bulk_deletion_log_{DateTimeOffset.UtcNow.ToString()}.txt");
-            var bulkDeletionMessage = await logChannel.SendFileAsync(fa, $"Finished wiping {channelName}, here's the bulk deletion log:");
+            var bulkDeletionMessage = await logChannel.SendFileAsync(fa, $"Finished wiping {channelName}, here's the bulk deletion log involving {involvedUserDescriptions}:");
 
             await ReplyAsync($"Finished wiping {channelName}. {messagesToDeleteCount} messages were deleted: {bulkDeletionMessage.GetJumpUrl()}");
         }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5285357/206595876-1859fe73-348e-4a2f-949a-07d89fe70a46.png)

The idea is that Discord searching someone's username or id will turn up logs involving them, which requires them to be in a text message rather than the file attachment, but it's probably overkill for the #modchat message.