### PR TITLE
don't apply the repeat penalty to empty messages

### DIFF
--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -204,7 +204,7 @@ public class SpamService
         }
 
         // Repeat pressure
-        if (message.CleanContent.ToLower() == _users[id].PreviousMessage.ToLower())
+        if (message.CleanContent.ToLower() == _users[id].PreviousMessage.ToLower() && message.CleanContent != "")
         {
             pressure += _config.SpamRepeatPressure;
             pressureBreakdown.Add((_config.SpamRepeatPressure, $"Repeat of Previous Message: {_config.SpamRepeatPressure}"));


### PR DESCRIPTION
We recently doubled our repeat penalty from 10 to 20, and the only case where we aren't happy about this change is multiple "empty" messages being considered repeats due to image posting. We already have a penalty for images, and those are the only reason empty content messages get posted in practice, so we want SpamImagePressure to be the primary factor in deciding how much image posting trips spam.

Confirmed on Bot Testing that the breakdowns Izzy logs no longer show a repeat penalty for repeated image-only messages.