### PR TITLE
delete timestamp on filter violation embed

### DIFF
--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -55,8 +55,7 @@ public class FilterService
             .AddField("Category", category, true)
             .AddField("Channel", $"<#{context.Channel.Id}>", true)
             .AddField("Trigger Word", $"{word}")
-            .AddField("Filtered Message", $"{context.Message.CleanContent}")
-            .WithTimestamp(onEdit ? (DateTimeOffset)context.Message.EditedTimestamp : context.Message.Timestamp);
+            .AddField("Filtered Message", $"{context.Message.CleanContent}");
 
         var actions = new List<string>();
         actions.Add(":x: - **I've deleted the offending message.**");


### PR DESCRIPTION
The other day this timestamp was a nonsense value like 10/10/2010. We assume this is because the message had already been deleted so Discord no longer had a real value for it. But this timestamp is redundant anyway (unless Izzy somehow takes days to delete a filtered message), so better to delete it than worry about trying to work around that glitch.