### PR TITLE
resolve async/await-related warnings

### DIFF
--- a/Izzy-Moonbot/EventListeners/ConfigListener.cs
+++ b/Izzy-Moonbot/EventListeners/ConfigListener.cs
@@ -32,7 +32,7 @@ public class ConfigListener
 
     public async Task ConfigChangeEvent(ConfigValueChangeEvent e, DiscordSocketClient client)
     {
-        await _logger.Log($"Config value change: {e.Name} from {e.Original} to {e.Current}", level: LogLevel.Debug);
+        _logger.Log($"Config value change: {e.Name} from {e.Original} to {e.Current}", level: LogLevel.Debug);
 
         switch (e.Name)
         {
@@ -62,12 +62,12 @@ public class ConfigListener
             var currentTime = DateTimeOffset.UtcNow;
             var executeTime = currentTime.AddMinutes(_config.BannerInterval);
             
-            await _logger.Log($"Adding scheduled job to run the banner rotation job in {_config.BannerInterval} minutes", level: LogLevel.Debug);
+            _logger.Log($"Adding scheduled job to run the banner rotation job in {_config.BannerInterval} minutes", level: LogLevel.Debug);
             Dictionary<string, string> fields = new Dictionary<string, string>();
             var action = new ScheduledBannerRotationJob();
             var job = new ScheduledJob(currentTime, executeTime, action, ScheduledJobRepeatType.Relative);
             await _schedule.CreateScheduledJob(job);
-            await _logger.Log($"Added scheduled job.", level: LogLevel.Debug);
+            _logger.Log($"Added scheduled job.", level: LogLevel.Debug);
             await _schedule.Unicycle_BannerRotation(action, new SocketGuildAdapter(client.GetGuild(DiscordHelper.DefaultGuild())), new DiscordSocketClientAdapter(client));
         }
         else if (original != BannerMode.None && current == BannerMode.None)
@@ -75,7 +75,7 @@ public class ConfigListener
             // Delete repeated job.
             var scheduledJobs = _schedule.GetScheduledJobs(job => job.Action is ScheduledBannerRotationJob);
 
-            await _logger.Log($"Cancelling all scheduled jobs for banner rotation.", level: LogLevel.Debug);
+            _logger.Log($"Cancelling all scheduled jobs for banner rotation.", level: LogLevel.Debug);
             foreach (var scheduledJob in scheduledJobs)
             {
                 await _schedule.DeleteScheduledJob(scheduledJob);
@@ -103,7 +103,7 @@ public class ConfigListener
         
         var scheduledJobs = _schedule.GetScheduledJobs(job => job.Action is ScheduledBannerRotationJob);
 
-        await _logger.Log($"Updating all scheduled jobs for banner rotation to occur {current} minutes after enabling rotation instead of after {original} minutes.", level: LogLevel.Debug);
+        _logger.Log($"Updating all scheduled jobs for banner rotation to occur {current} minutes after enabling rotation instead of after {original} minutes.", level: LogLevel.Debug);
         foreach (var scheduledJob in scheduledJobs)
         {
             scheduledJob.ExecuteAt = scheduledJob.CreatedAt.AddMinutes(current);

--- a/Izzy-Moonbot/EventListeners/UserListener.cs
+++ b/Izzy-Moonbot/EventListeners/UserListener.cs
@@ -47,7 +47,7 @@ public class UserListener
     {
         if (guild.Id != DiscordHelper.DefaultGuild()) return;
         
-        await _logger.Log($"User was unbanned: {user.Username}#{user.Discriminator}.", level: LogLevel.Debug);
+        _logger.Log($"User was unbanned: {user.Username}#{user.Discriminator}.", level: LogLevel.Debug);
         var scheduledJobs = _schedule.GetScheduledJobs(job => 
             job.Action switch
             {
@@ -55,64 +55,64 @@ public class UserListener
                 _ => false
             }
         );
-        await _logger.Log($"Cancelling all scheduled unban jobs for this user", level: LogLevel.Debug);
+        _logger.Log($"Cancelling all scheduled unban jobs for this user", level: LogLevel.Debug);
         foreach (var scheduledJob in scheduledJobs)
         {
             await _schedule.DeleteScheduledJob(scheduledJob);
         }
-        await _logger.Log($"Cancelled all scheduled unban jobs for this user", level: LogLevel.Debug);
+        _logger.Log($"Cancelled all scheduled unban jobs for this user", level: LogLevel.Debug);
     }
 
     public async Task MemberJoinEvent(SocketGuildUser member, bool catchingUp = false)
     {
         if (member.Guild.Id != DiscordHelper.DefaultGuild()) return;
         
-        await _logger.Log($"New member join{(catchingUp ? " found after reboot" : "")}: {member.Username}#{member.DiscriminatorValue} ({member.Id})", level: LogLevel.Debug);
+        _logger.Log($"New member join{(catchingUp ? " found after reboot" : "")}: {member.Username}#{member.DiscriminatorValue} ({member.Id})", level: LogLevel.Debug);
         if (!_users.ContainsKey(member.Id))
         {
-            await _logger.Log($"No user data entry for new user, generating one now...", level: LogLevel.Debug);
+            _logger.Log($"No user data entry for new user, generating one now...", level: LogLevel.Debug);
             User newUser = new User();
             newUser.Username = $"{member.Username}#{member.Discriminator}";
             newUser.Aliases.Add(member.Username);
             newUser.Joins.Add(member.JoinedAt.Value); // I really fucking hope it isn't null the user literally just joined
             _users.Add(member.Id, newUser);
             await FileHelper.SaveUsersAsync(_users);
-            await _logger.Log($"New user data entry generated.", level: LogLevel.Debug);
+            _logger.Log($"New user data entry generated.", level: LogLevel.Debug);
         }
         else if (!catchingUp)
         {
-            await _logger.Log($"Found user data entry for new user, add new join date", level: LogLevel.Debug);
+            _logger.Log($"Found user data entry for new user, add new join date", level: LogLevel.Debug);
             _users[member.Id].Joins.Add(member.JoinedAt.Value); // I still really fucking hope it isn't null because the user did just join
             await FileHelper.SaveUsersAsync(_users);
-            await _logger.Log($"Added new join date for new user", level: LogLevel.Debug);
+            _logger.Log($"Added new join date for new user", level: LogLevel.Debug);
         }
         
         List<ulong> roles = new List<ulong>();
         string expiresString = "";
 
-        await _logger.Log($"Processing roles for new user join", level: LogLevel.Debug);
+        _logger.Log($"Processing roles for new user join", level: LogLevel.Debug);
         if (_config.ManageNewUserRoles && _config.MemberRole != null && !(_config.AutoSilenceNewJoins || _users[member.Id].Silenced))
         {
-            await _logger.Log($"Adding Config.MemberRole ({_config.MemberRole}) to new user", level: LogLevel.Debug);
+            _logger.Log($"Adding Config.MemberRole ({_config.MemberRole}) to new user", level: LogLevel.Debug);
             roles.Add((ulong)_config.MemberRole);
         }
 
         if (_config.ManageNewUserRoles && _config.NewMemberRole != null && (!_config.AutoSilenceNewJoins || !_users[member.Id].Silenced))
         {
-            await _logger.Log($"Adding Config.NewMemberRole ({_config.NewMemberRole}) to new user", level: LogLevel.Debug);
+            _logger.Log($"Adding Config.NewMemberRole ({_config.NewMemberRole}) to new user", level: LogLevel.Debug);
             roles.Add((ulong)_config.NewMemberRole);
             expiresString = $"{Environment.NewLine}New Member role expires in <t:{(DateTimeOffset.UtcNow + TimeSpan.FromMinutes(_config.NewMemberRoleDecay)).ToUnixTimeSeconds()}:R>";
 
-            await _logger.Log($"Adding scheduled job to remove Config.NewMemberRole from new user in {_config.NewMemberRoleDecay} minutes", level: LogLevel.Debug);
+            _logger.Log($"Adding scheduled job to remove Config.NewMemberRole from new user in {_config.NewMemberRoleDecay} minutes", level: LogLevel.Debug);
             var action = new ScheduledRoleRemovalJob(_config.NewMemberRole.Value, member.Id,
                 $"New member role removal, {_config.NewMemberRoleDecay} minutes (`NewMemberRoleDecay`) passed.");
             var task = new ScheduledJob(DateTimeOffset.UtcNow, 
                 (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(_config.NewMemberRoleDecay)), action);
             await _schedule.CreateScheduledJob(task);
-            await _logger.Log($"Added scheduled job for new user", level: LogLevel.Debug);
+            _logger.Log($"Added scheduled job for new user", level: LogLevel.Debug);
         }
         
-        await _logger.Log($"Generating action reason", level: LogLevel.Debug);
+        _logger.Log($"Generating action reason", level: LogLevel.Debug);
         
         string autoSilence = $" (User autosilenced, `AutoSilenceNewJoins` is true.)";
         
@@ -122,10 +122,10 @@ public class UserListener
             if (_users[member.Id].Silenced)
                 autoSilence = 
                     ", silenced (attempted silence bypass)";
-            await _logger.Log($"Generated action reason, executing action", level: LogLevel.Debug);
+            _logger.Log($"Generated action reason, executing action", level: LogLevel.Debug);
 
             await _mod.AddRoles(member, roles, $"New user join{autoSilence}.{expiresString}"); 
-            await _logger.Log($"Action executed, generating moderation log content", level: LogLevel.Debug);
+            _logger.Log($"Action executed, generating moderation log content", level: LogLevel.Debug);
         }
 
         autoSilence = ", silenced (`AutoSilenceNewJoins` is on)";
@@ -144,7 +144,7 @@ public class UserListener
             
             if (!member.Guild.Roles.Select(role => role.Id).Contains(roleId))
             {
-                await _logger.Log(
+                _logger.Log(
                     $"{member.Username}#{member.Discriminator} ({member.Id}) had role which would of reapplied on join but no longer exists, role id {roleId}");
                 _users[member.Id].RolesToReapplyOnRejoin.Remove(roleId);
                 _config.RolesToReapplyOnRejoin.Remove(roleId);
@@ -157,7 +157,7 @@ public class UserListener
 
                 if (!_config.RolesToReapplyOnRejoin.Contains(roleId))
                 {
-                    await _logger.Log(
+                    _logger.Log(
                         $"{member.Username}#{member.Discriminator} ({member.Id}) has role which will no longer reapply on join, role {member.Guild.Roles.Single(role => role.Id == roleId).Name} ({roleId})");
                     _users[member.Id].RolesToReapplyOnRejoin.Remove(roleId);
                     await FileHelper.SaveUsersAsync(_users);
@@ -176,20 +176,20 @@ public class UserListener
 
         if (rolesAutoapplied.Count == 0) rolesAutoappliedString = "";
         
-        await _logger.Log($"Generated moderation log content, posting log", level: LogLevel.Debug);
+        _logger.Log($"Generated moderation log content, posting log", level: LogLevel.Debug);
         
         await _modLogger.CreateModLog(member.Guild)
             .SetContent($"{(catchingUp ? "Catching up on ": "")}Join: <@{member.Id}> (`{member.Id}`), created <t:{member.CreatedAt.ToUnixTimeSeconds()}:R>{autoSilence}{joinedBefore}{rolesAutoappliedString}")
             .SetFileLogContent($"{(catchingUp ? "Catching up on ": "")}Join: {member.Username}#{member.Discriminator} (`{member.Id}`), created {member.CreatedAt:O}{autoSilence}{joinedBefore}{rolesAutoappliedString}")
             .Send();
-        await _logger.Log($"Log posted", level: LogLevel.Debug);
+        _logger.Log($"Log posted", level: LogLevel.Debug);
     }
     
     private async Task MemberLeaveEvent(SocketGuild guild, SocketUser user)
     {
         if (guild.Id != DiscordHelper.DefaultGuild()) return;
         
-        await _logger.Log($"Member leaving: {user.Username}#{user.Discriminator} ({user.Id}), getting last nickname", level: LogLevel.Debug);
+        _logger.Log($"Member leaving: {user.Username}#{user.Discriminator} ({user.Id}), getting last nickname", level: LogLevel.Debug);
         var lastNickname = "";
         try
         {
@@ -199,7 +199,7 @@ public class UserListener
         {
             lastNickname = "<UNKNOWN>";
         }
-        await _logger.Log($"Last nickname was {lastNickname}, checking whether user was kicked or banned", level: LogLevel.Debug);
+        _logger.Log($"Last nickname was {lastNickname}, checking whether user was kicked or banned", level: LogLevel.Debug);
         var wasKicked = guild.GetAuditLogsAsync(2, actionType: ActionType.Kick).FirstAsync()
             .GetAwaiter().GetResult()
             .Select(audit =>
@@ -226,7 +226,7 @@ public class UserListener
                 return null;
             });
 
-        await _logger.Log($"Constructing moderation log content", level: LogLevel.Debug);
+        _logger.Log($"Constructing moderation log content", level: LogLevel.Debug);
         var output = 
             $"Leave: {user.Username}#{user.Discriminator} ({lastNickname}) (`{user.Id}`) joined <t:{_users[user.Id].Joins.Last().ToUnixTimeSeconds()}:R>";
         var fileOutput = 
@@ -235,9 +235,9 @@ public class UserListener
         var banAuditLogEntries = wasBanned as RestAuditLogEntry[] ?? wasBanned.ToArray();
         if (banAuditLogEntries.Any(audit => audit != null))
         {
-            await _logger.Log($"User was banned, fetching the reason and moderator", level: LogLevel.Debug);
+            _logger.Log($"User was banned, fetching the reason and moderator", level: LogLevel.Debug);
             var audit = banAuditLogEntries.First();
-            await _logger.Log($"Fetched, user was banned by {audit.User.Username}#{audit.User.Discriminator} ({audit.User.Id}) for \"{audit.Reason}\"", level: LogLevel.Debug);
+            _logger.Log($"Fetched, user was banned by {audit.User.Username}#{audit.User.Discriminator} ({audit.User.Id}) for \"{audit.Reason}\"", level: LogLevel.Debug);
             output =
                 $"Leave (Ban): {user.Username}#{user.Discriminator} ({lastNickname}) (`{user.Id}`) joined <t:{_users[user.Id].Joins.Last().ToUnixTimeSeconds()}:R>, \"{audit.Reason}\" by {audit.User.Username}#{audit.User.Discriminator} ({guild.GetUser(audit.User.Id).DisplayName})";
             fileOutput =
@@ -247,17 +247,17 @@ public class UserListener
         var kickAuditLogEntries = wasKicked as RestAuditLogEntry[] ?? wasKicked.ToArray();
         if (kickAuditLogEntries.Any(audit => audit != null))
         {
-            await _logger.Log($"User was kicked, fetching the reason and moderator", level: LogLevel.Debug);
+            _logger.Log($"User was kicked, fetching the reason and moderator", level: LogLevel.Debug);
             var audit = kickAuditLogEntries.First();
-            await _logger.Log($"Fetched, user was kicked by {audit.User.Username}#{audit.User.Discriminator} ({audit.User.Id}) for \"{audit.Reason}\"", level: LogLevel.Debug);
+            _logger.Log($"Fetched, user was kicked by {audit.User.Username}#{audit.User.Discriminator} ({audit.User.Id}) for \"{audit.Reason}\"", level: LogLevel.Debug);
             output =
                 $"Leave (Kick): {user.Username}#{user.Discriminator} ({lastNickname}) (`{user.Id}`) joined <t:{_users[user.Id].Joins.Last().ToUnixTimeSeconds()}:R>, \"{audit.Reason}\" by {audit.User.Username}#{audit.User.Discriminator} ({guild.GetUser(audit.User.Id).DisplayName})";
             fileOutput =
                 $"Leave (Kick): {user.Username}#{user.Discriminator} ({lastNickname}) (`{user.Id}`) joined {_users[user.Id].Joins.Last():O}, \"{audit.Reason}\" by {audit.User.Username}#{audit.User.Discriminator} ({guild.GetUser(audit.User.Id).DisplayName})";
         }
-        await _logger.Log($"Finished constructing moderation log content", level: LogLevel.Debug);
+        _logger.Log($"Finished constructing moderation log content", level: LogLevel.Debug);
 
-        await _logger.Log($"Fetch all scheduled jobs for this user", level: LogLevel.Debug);
+        _logger.Log($"Fetch all scheduled jobs for this user", level: LogLevel.Debug);
         var scheduledTasks = _schedule.GetScheduledJobs(job => 
             job.Action switch
             {
@@ -266,20 +266,20 @@ public class UserListener
                 _ => false
             }
         );
-        await _logger.Log($"Cancelling all scheduled jobs for this user", level: LogLevel.Debug);
+        _logger.Log($"Cancelling all scheduled jobs for this user", level: LogLevel.Debug);
         foreach (var scheduledTask in scheduledTasks.Where(scheduledTask => 
                      scheduledTask.Action is not ScheduledUnbanJob))
         {
             await _schedule.DeleteScheduledJob(scheduledTask);
         }
-        await _logger.Log($"Cancelled all scheduled jobs for this user", level: LogLevel.Debug);
+        _logger.Log($"Cancelled all scheduled jobs for this user", level: LogLevel.Debug);
 
-        await _logger.Log($"Sending moderation log", level: LogLevel.Debug);
+        _logger.Log($"Sending moderation log", level: LogLevel.Debug);
         await _modLogger.CreateModLog(guild)
             .SetContent(output)
             .SetFileLogContent(fileOutput)
             .Send();
-        await _logger.Log($"Moderation log sent", level: LogLevel.Debug);
+        _logger.Log($"Moderation log sent", level: LogLevel.Debug);
     }
 
     private async Task MemberUpdateEvent(Cacheable<SocketGuildUser,ulong> oldUser, SocketGuildUser newUser)
@@ -291,7 +291,7 @@ public class UserListener
         if (!_users.ContainsKey(newUser.Id))
         {
             changed = true;
-            await _logger.Log($"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) has no metadata, creating now...", level: LogLevel.Debug);
+            _logger.Log($"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) has no metadata, creating now...", level: LogLevel.Debug);
             var newUserData = new User();
             newUserData.Username = $"{newUser.Username}#{newUser.Discriminator}";
             newUserData.Aliases.Add(newUser.Username);
@@ -302,7 +302,7 @@ public class UserListener
         {
             if (_users[newUser.Id].Username != $"{newUser.Username}#{newUser.Discriminator}")
             {
-                await _logger.Log($"User name/discriminator changed from {_users[newUser.Id].Username} to {newUser.Username}#{newUser.Discriminator}, updating...", level: LogLevel.Debug);
+                _logger.Log($"User name/discriminator changed from {_users[newUser.Id].Username} to {newUser.Username}#{newUser.Discriminator}, updating...", level: LogLevel.Debug);
                 _users[newUser.Id].Username =
                     $"{newUser.Username}#{newUser.Discriminator}";
                 changed = true;
@@ -310,7 +310,7 @@ public class UserListener
 
             if (!_users[newUser.Id].Aliases.Contains(newUser.DisplayName))
             {
-                await _logger.Log($"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) has new displayname, updating...", level: LogLevel.Debug);
+                _logger.Log($"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) has new displayname, updating...", level: LogLevel.Debug);
                 _users[newUser.Id].Aliases.Add(newUser.DisplayName);
                 changed = true;
             }
@@ -322,7 +322,7 @@ public class UserListener
                 newUser.Roles.Select(role => role.Id).Contains((ulong)_config.MemberRole))
             {
                 // Unsilenced, Remove the flag.
-                await _logger.Log(
+                _logger.Log(
                     $"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) unsilenced, removing silence flag...");
                 _users[newUser.Id].Silenced = false;
                 changed = true;
@@ -332,7 +332,7 @@ public class UserListener
                 !newUser.Roles.Select(role => role.Id).Contains((ulong)_config.MemberRole))
             {
                 // Silenced, add the flag
-                await _logger.Log(
+                _logger.Log(
                     $"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) silenced, adding silence flag...");
                 _users[newUser.Id].Silenced = true;
                 changed = true;
@@ -344,7 +344,7 @@ public class UserListener
             if (!_users[newUser.Id].RolesToReapplyOnRejoin.Contains(roleId) &&
                 newUser.Roles.Select(role => role.Id).Contains(roleId))
             {
-                await _logger.Log(
+                _logger.Log(
                     $"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) gained role which will reapply on join, role {newUser.Roles.Single(role => role.Id == roleId).Name} ({roleId})");
                 _users[newUser.Id].RolesToReapplyOnRejoin.Add(roleId);
                 changed = true;
@@ -353,7 +353,7 @@ public class UserListener
             if (_users[newUser.Id].RolesToReapplyOnRejoin.Contains(roleId) &&
                 !newUser.Roles.Select(role => role.Id).Contains(roleId))
             {
-                await _logger.Log(
+                _logger.Log(
                     $"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) lost role which would reapply on join, role {newUser.Guild.Roles.Single(role => role.Id == roleId).Name} ({roleId})");
                 _users[newUser.Id].RolesToReapplyOnRejoin.Remove(roleId);
                 changed = true;
@@ -364,7 +364,7 @@ public class UserListener
         {
             if (!newUser.Guild.Roles.Select(role => role.Id).Contains(roleId))
             {
-                await _logger.Log(
+                _logger.Log(
                     $"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) had role which would of reapplied on join but no longer exists, role id {roleId}");
                 _users[newUser.Id].RolesToReapplyOnRejoin.Remove(roleId);
                 _config.RolesToReapplyOnRejoin.Remove(roleId);
@@ -376,7 +376,7 @@ public class UserListener
 
                 if (!_config.RolesToReapplyOnRejoin.Contains(roleId))
                 {
-                    await _logger.Log(
+                    _logger.Log(
                         $"{newUser.Username}#{newUser.Discriminator} ({newUser.Id}) has role which will no longer reapply on join, role {newUser.Guild.Roles.Single(role => role.Id == roleId).Name} ({roleId})");
                     _users[newUser.Id].RolesToReapplyOnRejoin.Remove(roleId);
                     changed = true;

--- a/Izzy-Moonbot/Izzy-Moonbot.csproj
+++ b/Izzy-Moonbot/Izzy-Moonbot.csproj
@@ -5,6 +5,12 @@
         <Nullable>enable</Nullable>
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <NoWarn>1701;1702;1998</NoWarn>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <NoWarn>1701;1702;1998</NoWarn>
+    </PropertyGroup>
 
     <ItemGroup>
         <Compile Remove="BotSettings\**" />

--- a/Izzy-Moonbot/Modules/AdminModule.cs
+++ b/Izzy-Moonbot/Modules/AdminModule.cs
@@ -104,7 +104,7 @@ public class AdminModule : ModuleBase<SocketCommandContext>
     [DevCommand(Group = "Permissions")]
     public async Task ScanCommandAsync()
     {
-        Task.Run(async () =>
+        var _ = Task.Run(async () =>
         {
             if (!Context.Guild.HasAllMembers) await Context.Guild.DownloadUsersAsync();
 
@@ -732,12 +732,12 @@ public class AdminModule : ModuleBase<SocketCommandContext>
             // If a duration was provided, schedule removal.
             if (time is not null)
             {
-                await _logger.Log($"Adding scheduled job to remove role {roleId} from user {userId} at {time.Time}", level: LogLevel.Debug);
+                _logger.Log($"Adding scheduled job to remove role {roleId} from user {userId} at {time.Time}", level: LogLevel.Debug);
                 var action = new ScheduledRoleRemovalJob(roleId, member.Id,
                     $".assignrole command for user {member.Id} and role {roleId} with duration {duration}.");
                 var task = new ScheduledJob(DateTimeOffset.UtcNow, time.Time, action);
                 await _schedule.CreateScheduledJob(task);
-                await _logger.Log($"Added scheduled job for new user", level: LogLevel.Debug);
+                _logger.Log($"Added scheduled job for new user", level: LogLevel.Debug);
 
                 if (hasExistingRemovalJob)
                 {
@@ -839,7 +839,7 @@ public class AdminModule : ModuleBase<SocketCommandContext>
             return;
         }
 
-        await _logger.Log($"Parsed .wipe command arguments. Scanning for messages in channel {channelName} more recent than {wipeThreshold}");
+        _logger.Log($"Parsed .wipe command arguments. Scanning for messages in channel {channelName} more recent than {wipeThreshold}");
 
         // Gather up all the messages we need to delete and log.
 
@@ -868,7 +868,7 @@ public class AdminModule : ModuleBase<SocketCommandContext>
 
         // Actually do the deletion
         var messagesToDeleteCount = messageIdsToDelete.Count;
-        await _logger.Log($"Deleting {messagesToDeleteCount} messages from channel {channelName}");
+        _logger.Log($"Deleting {messagesToDeleteCount} messages from channel {channelName}");
         var discordBulkDeletionLimit = 100;
         while (messageIdsToDelete.Any())
         {
@@ -894,7 +894,7 @@ public class AdminModule : ModuleBase<SocketCommandContext>
 
         if (messagesToDeleteCount > 0)
         {
-            await _logger.Log($"Assembling a bulk deletion log from the content of {messagesToDeleteCount} deleted messages");
+            _logger.Log($"Assembling a bulk deletion log from the content of {messagesToDeleteCount} deleted messages");
             bulkDeletionLog.Sort((x, y) => x.Item1.CompareTo(y.Item1));
 
             var bulkDeletionLogString = string.Join(

--- a/Izzy-Moonbot/Modules/ConfigModule.cs
+++ b/Izzy-Moonbot/Modules/ConfigModule.cs
@@ -1209,7 +1209,7 @@ public class ConfigModule : ModuleBase<SocketCommandContext>
             }
             else
             {
-                context.Message.ReplyAsync($"I couldn't determine what type {configItem.Type} is.");
+                await context.Message.ReplyAsync($"I couldn't determine what type {configItem.Type} is.");
             }
         }
     }

--- a/Izzy-Moonbot/Modules/MiscModule.cs
+++ b/Izzy-Moonbot/Modules/MiscModule.cs
@@ -161,13 +161,13 @@ public class MiscModule : ModuleBase<SocketCommandContext>
                 return;
             }
 
-            await _logger.Log($"Adding scheduled job to remind user to \"{content}\" at {timeHelperResponse.Time:F}",
+            _logger.Log($"Adding scheduled job to remind user to \"{content}\" at {timeHelperResponse.Time:F}",
                 context: context, level: LogLevel.Debug);
             var action = new ScheduledEchoJob(context.User, content);
             var task = new ScheduledJob(DateTimeOffset.UtcNow,
                 timeHelperResponse.Time, action);
             await _schedule.CreateScheduledJob(task);
-            await _logger.Log($"Added scheduled job for user", context: context, level: LogLevel.Debug);
+            _logger.Log($"Added scheduled job for user", context: context, level: LogLevel.Debug);
 
             await context.Channel.SendMessageAsync($"Okay! I'll DM you a reminder <t:{timeHelperResponse.Time.ToUnixTimeSeconds()}:R>.");
         }

--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -135,7 +135,7 @@ public class FilterService
 
             if (shouldSilence)
             {
-                _mod.SilenceUser(context.Guild.GetUser(context.User.Id), $"Filter violation ({category} category)");
+                await _mod.SilenceUser(context.Guild.GetUser(context.User.Id), $"Filter violation ({category} category)");
                 actions.Add("silence");
             }
 

--- a/Izzy-Moonbot/Service/LoggingService.cs
+++ b/Izzy-Moonbot/Service/LoggingService.cs
@@ -18,15 +18,15 @@ public class LoggingService
         _logger = logger;
     }
 
-    public async Task Log(string message, SocketCommandContext? context, LogLevel level = LogLevel.Information,
+    public void Log(string message, SocketCommandContext? context, LogLevel level = LogLevel.Information,
         [CallerMemberName] string memberName = "",
         [CallerFilePath] string sourceFilePath = "",
         [CallerLineNumber] int sourceLineNumber = 0)
     {
-        await Log(message, context is not null ? new SocketCommandContextAdapter(context) : null, level, memberName, sourceFilePath, sourceLineNumber);
+        Log(message, context is not null ? new SocketCommandContextAdapter(context) : null, level, memberName, sourceFilePath, sourceLineNumber);
     }
 
-    public async Task Log(string message, IIzzyContext? context = null, LogLevel level = LogLevel.Information,
+    public void Log(string message, IIzzyContext? context = null, LogLevel level = LogLevel.Information,
         [CallerMemberName] string memberName = "",
         [CallerFilePath] string sourceFilePath = "",
         [CallerLineNumber] int sourceLineNumber = 0)

--- a/Izzy-Moonbot/Service/RaidService.cs
+++ b/Izzy-Moonbot/Service/RaidService.cs
@@ -105,10 +105,10 @@ public class RaidService
             if (member is not { JoinedAt: { } }) return;
             if (member.JoinedAt.Value.AddSeconds(_config.RecentJoinDecay) < DateTimeOffset.Now)
             {
-                Task.Run(async () =>
+                var _ = Task.Run(async () =>
                 {
                     await Task.Delay(Convert.ToInt32((member.JoinedAt.Value.AddSeconds(_config.RecentJoinDecay) - DateTimeOffset.Now) * 1000));
-                    await _log.Log(
+                    _log.Log(
                         $"{member.DisplayName} ({member.Id}) no longer a recent join (after raid)");
                     _state.RecentJoins.Remove(member.Id);
                 });
@@ -146,10 +146,10 @@ public class RaidService
             if (member is not { JoinedAt: { } }) return;
             if (member.JoinedAt.Value.AddSeconds(_config.RecentJoinDecay) < DateTimeOffset.Now)
             {
-                Task.Run(async () =>
+                var _ = Task.Run(async () =>
                 {
                     await Task.Delay(Convert.ToInt32((member.JoinedAt.Value.AddSeconds(_config.RecentJoinDecay) - DateTimeOffset.Now) * 1000));
-                    await _log.Log(
+                    _log.Log(
                         $"{member.DisplayName} ({member.Id}) no longer a recent join (after raid)");
                     _state.RecentJoins.Remove(member.Id);
                 });
@@ -315,51 +315,51 @@ public class RaidService
         if (!UserRecentlyJoined(member.Id))
         {
             _state.CurrentSmallJoinCount++;
-            await _log.Log(
+            _log.Log(
                 $"Small raid join count raised for {member.DisplayName} ({member.Id}). Now at {_state.CurrentSmallJoinCount}/{_config.SmallRaidSize} for {_config.SmallRaidTime} seconds.",
                 level: LogLevel.Debug);
             _state.CurrentLargeJoinCount++;
-            await _log.Log(
+            _log.Log(
                 $"Large raid join count raised for {member.DisplayName} ({member.Id}). Now at {_state.CurrentLargeJoinCount}/{_config.LargeRaidSize} for {_config.LargeRaidTime} seconds.",
                 level: LogLevel.Debug);
 
             _state.RecentJoins.Add(member.Id);
 
-            await _log.Log(
+            _log.Log(
                 $"Recent join: {member.DisplayName} ({member.Id}), No longer considered recent join in {_config.RecentJoinDecay} seconds.");
 
             await CheckForTrip(member.Guild);
 
-            Task.Run(async () =>
+            var _ = Task.Run(async () =>
             {
                 await Task.Delay(Convert.ToInt32(_config.SmallRaidTime * 1000));
                 _state.CurrentSmallJoinCount--;
-                await _log.Log(
+                _log.Log(
                     $"Small raid join count dropped for {member.DisplayName} ({member.Id}). Now at {_state.CurrentSmallJoinCount}./{_config.SmallRaidSize} after {_config.SmallRaidTime} seconds.",
                     level: LogLevel.Debug);
             });
 
-            Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 await Task.Delay(Convert.ToInt32(_config.LargeRaidTime * 1000));
                 _state.CurrentLargeJoinCount--;
-                await _log.Log(
+                _log.Log(
                     $"Large raid join count dropped for {member.DisplayName} ({member.Id}). Now at {_state.CurrentLargeJoinCount}/{_config.LargeRaidSize} after {_config.LargeRaidTime} seconds.",
                     level: LogLevel.Debug);
             });
 
-            Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 await Task.Delay(Convert.ToInt32(_config.RecentJoinDecay * 1000));
                 if (_generalStorage.CurrentRaidMode == RaidMode.None)
                 {
-                    await _log.Log(
+                    _log.Log(
                         $"{member.DisplayName} ({member.Id}) no longer a recent join");
                     _state.RecentJoins.Remove(member.Id);
                 }
             });
             if (_config.SmallRaidDecay != null)
-                Task.Run(async () =>
+                _ = Task.Run(async () =>
                 {
                     await Task.Delay(Convert.ToInt32(_config.SmallRaidDecay * 60 * 1000));
                     if (_config.SmallRaidDecay == null) return; // Was disabled
@@ -368,11 +368,11 @@ public class RaidService
                         return; // Small raid join count is still ongoing.
                     if (_generalStorage.ManualRaidSilence) return; // This raid was manually silenced. Don't decay.
 
-                    await _log.Log("Decaying raid: Small -> None", level: LogLevel.Debug);
+                    _log.Log("Decaying raid: Small -> None", level: LogLevel.Debug);
                     await DecaySmallRaid(member.Guild);
                 });
             if (_config.LargeRaidDecay != null)
-                Task.Run(async () =>
+                _ = Task.Run(async () =>
                 {
                     await Task.Delay(Convert.ToInt32(_config.LargeRaidDecay * 60 * 1000));
                     if (_config.SmallRaidDecay == null) return; // Was disabled
@@ -380,7 +380,7 @@ public class RaidService
                     if (_state.CurrentLargeJoinCount > _config.SmallRaidSize)
                         return; // Large raid join count is still ongoing.
 
-                    await _log.Log("Decaying raid: Large -> Small", level: LogLevel.Debug);
+                    _log.Log("Decaying raid: Large -> Small", level: LogLevel.Debug);
                     await DecayLargeRaid(member.Guild);
                 });
         }

--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -62,7 +62,7 @@ public class ScheduleService
             }
             catch (Exception exception)
             {
-                await _logger.Log($"{exception.Message}{Environment.NewLine}{exception.StackTrace}", level: LogLevel.Error);
+                _logger.Log($"{exception.Message}{Environment.NewLine}{exception.StackTrace}", level: LogLevel.Error);
             }
 
             // Call self
@@ -84,7 +84,7 @@ public class ScheduleService
 
         foreach (var job in scheduledJobsToExecute)
         {
-            await _logger.Log($"Executing scheduled job queued for execution at {job.ExecuteAt:F}", level: LogLevel.Debug);
+            _logger.Log($"Executing scheduled job queued for execution at {job.ExecuteAt:F}", level: LogLevel.Debug);
 
             try
             {
@@ -118,7 +118,7 @@ public class ScheduleService
             }
             catch (Exception ex)
             {
-                await _logger.Log(
+                _logger.Log(
                     $"Scheduled job threw an exception when trying to execute!{Environment.NewLine}" +
                     $"Type: {ex.GetType().Name}{Environment.NewLine}" +
                     $"Message: {ex.Message}{Environment.NewLine}" +
@@ -231,7 +231,7 @@ public class ScheduleService
 
         var reason = job.Reason;
         
-        await _logger.Log(
+        _logger.Log(
             $"Adding {role.Name} ({role.Id}) to {user.Username}#{user.Discriminator} ({user.Id})", level: LogLevel.Debug);
         
         await _mod.AddRole(user, role.Id, reason);
@@ -251,7 +251,7 @@ public class ScheduleService
 
         string? reason = job.Reason;
         
-        await _logger.Log(
+        _logger.Log(
             $"Removing {role.Name} ({role.Id}) from {user.Username}#{user.Discriminator} ({user.Id})", level: LogLevel.Debug);
         
         await _mod.RemoveRole(user, role.Id, reason);
@@ -269,7 +269,7 @@ public class ScheduleService
 
         var user = await client.GetUserAsync(job.User);
         
-        await _logger.Log(
+        _logger.Log(
             $"Unbanning {(user == null ? job.User : $"")}.",
             level: LogLevel.Debug);
 
@@ -324,7 +324,7 @@ public class ScheduleService
                 }
                 catch (FlurlHttpException ex)
                 {
-                    await _logger.Log($"Recieved HTTP exception when executing Banner Rotation: {ex.Message}");
+                    _logger.Log($"Recieved HTTP exception when executing Banner Rotation: {ex.Message}");
                     return;
                 }
 
@@ -347,7 +347,7 @@ public class ScheduleService
                     .SetFileLogContent(
                         $"Tried to change banner but the host server didn't respond fast enough, is it down? If so please run `.config BannerMode None` to avoid unnecessarily pinging Manebooru.")
                     .Send();
-                await _logger.Log(
+                _logger.Log(
                     $"Encountered HTTP timeout exception when trying to change banner: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
             catch (FlurlHttpException ex)
@@ -359,7 +359,7 @@ public class ScheduleService
                     .SetFileLogContent(
                         $"Tried to change banner and received a {ex.StatusCode} status code when attempting to ask the host server for the image. Doing nothing.")
                     .Send();
-                await _logger.Log(
+                _logger.Log(
                     $"Encountered HTTP exception when trying to change banner: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
             catch (Exception ex)
@@ -370,7 +370,7 @@ public class ScheduleService
                     .SetFileLogContent(
                         $"Tried to change banner and received a general error when attempting to ask the host server for the image. Doing nothing.")
                     .Send();
-                await _logger.Log(
+                _logger.Log(
                     $"Encountered exception when trying to change banner: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
         }
@@ -440,7 +440,7 @@ public class ScheduleService
                     .SetFileLogContent(
                         $"Tried to change banner but Manebooru didn't respond fast enough, is it down? If so please run `.config BannerMode None` to avoid unnecessarily pinging Manebooru.")
                     .Send();
-                await _logger.Log(
+                _logger.Log(
                     $"Encountered HTTP timeout exception when trying to change banner: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
             catch (FlurlHttpException ex)
@@ -460,7 +460,7 @@ public class ScheduleService
                         $"  - Manebooru thinks I sent a badly formatted request when I didn't.\n" +
                         $"  - Manebooru is down and Cloudflare is giving me a error page.")
                     .Send();
-                await _logger.Log(
+                _logger.Log(
                     $"Encountered HTTP exception when trying to change banner: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
             catch (Exception ex)
@@ -479,7 +479,7 @@ public class ScheduleService
                         $"  - This server cannot have a banner.\n" +
                         $"  - The banner rotation job is an unexpected state.")
                     .Send();
-                await _logger.Log(
+                _logger.Log(
                     $"Encountered exception when trying to change banner: {ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
         }

--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -258,7 +258,7 @@ public class SpamService
 
         var newPressure = await IncreasePressure(id, pressure);
 
-        await _logger.Log($"Pressure increase from {oldPressureAfterDecay} by {pressure} to {newPressure}/{_config.SpamMaxPressure}. Pressure breakdown: {string.Join('\n', pressureBreakdown)}", context, level: LogLevel.Debug);
+        _logger.Log($"Pressure increase from {oldPressureAfterDecay} by {pressure} to {newPressure}/{_config.SpamMaxPressure}. Pressure breakdown: {string.Join('\n', pressureBreakdown)}", context, level: LogLevel.Debug);
 
         // If this user already tripped spam pressure, but was either immune to silencing or managed to
         // send another message before Izzy could respond, we don't want duplicate notifications
@@ -266,13 +266,13 @@ public class SpamService
 
         if (newPressure >= _config.SpamMaxPressure)
         {
-            await _logger.Log("Spam pressure trip, checking whether user should be silenced or not...", context, level: LogLevel.Debug);
+            _logger.Log("Spam pressure trip, checking whether user should be silenced or not...", context, level: LogLevel.Debug);
             var roleIds = user.Roles.Select(roles => roles.Id).ToList();
             if (_config.SpamBypassRoles.Overlaps(roleIds) || 
                 (DiscordHelper.IsDev(user.Id) && _config.SpamDevBypass))
             {
                 // User has a role which bypasses the punishment of spam trigger. Mention it in action log.
-                await _logger.Log("No silence, user has role(s) in Config.SpamBypassRoles", context, level: LogLevel.Debug);
+                _logger.Log("No silence, user has role(s) in Config.SpamBypassRoles", context, level: LogLevel.Debug);
 
                 if (alreadyAlerted) return;
 
@@ -297,7 +297,7 @@ public class SpamService
             else
             {
                 // User is not immune to spam punishments, process trip.
-                await _logger.Log("Silence, executing trip method.", context, level: LogLevel.Debug);
+                _logger.Log("Silence, executing trip method.", context, level: LogLevel.Debug);
                 await ProcessTrip(id, oldPressureAfterDecay, newPressure, pressureBreakdown, message, user, context, alreadyAlerted);
             }
         }
@@ -341,12 +341,12 @@ public class SpamService
             catch (Exception ex)
             {
                 // Something funky is going on here
-                await _logger.Log($"Exception occured while trying to delete message, assuming deleted.", level: LogLevel.Warning);
-                await _logger.Log($"Message ID: {previousMessageItem.Id}", level: LogLevel.Warning);
-                await _logger.Log($"Message: {ex.Message}", level: LogLevel.Warning);
-                await _logger.Log($"Source: {ex.Source}", level: LogLevel.Warning);
-                await _logger.Log($"Method: {ex.TargetSite}", level: LogLevel.Warning);
-                await _logger.Log($"Stack Trace: {ex.StackTrace}", level: LogLevel.Warning);
+                _logger.Log($"Exception occured while trying to delete message, assuming deleted.", level: LogLevel.Warning);
+                _logger.Log($"Message ID: {previousMessageItem.Id}", level: LogLevel.Warning);
+                _logger.Log($"Message: {ex.Message}", level: LogLevel.Warning);
+                _logger.Log($"Source: {ex.Source}", level: LogLevel.Warning);
+                _logger.Log($"Method: {ex.TargetSite}", level: LogLevel.Warning);
+                _logger.Log($"Stack Trace: {ex.StackTrace}", level: LogLevel.Warning);
 
                 alreadyDeletedMessages++;
             }
@@ -357,13 +357,13 @@ public class SpamService
         {
             var logChannelId = _config.LogChannel;
             if (logChannelId == 0)
-                await _logger.Log("I couldn't post a bulk deletion log, because .config LogChannel hasn't been set.");
+                _logger.Log("I couldn't post a bulk deletion log, because .config LogChannel hasn't been set.");
             else
             {
                 var logChannel = context.Guild.GetTextChannel(logChannelId);
                 if (logChannel is not null)
                 {
-                    await _logger.Log($"Assembling a bulk deletion log from the content of {bulkDeletionLog.Count} deleted messages");
+                    _logger.Log($"Assembling a bulk deletion log from the content of {bulkDeletionLog.Count} deleted messages");
                     bulkDeletionLog.Sort((x, y) => x.Item1.CompareTo(y.Item1));
                     var bulkDeletionLogString = string.Join("\n\n", bulkDeletionLog.Select(logElement => logElement.Item2));
                     var s = new MemoryStream(Encoding.UTF8.GetBytes(bulkDeletionLogString));
@@ -374,7 +374,7 @@ public class SpamService
                     bulkLogJumpUrl = spamBulkDeletionMessage.GetJumpUrl();
                 }
                 else
-                    await _logger.Log("Something went wrong trying to access LogChannel.");
+                    _logger.Log("Something went wrong trying to access LogChannel.");
             }
         }
 

--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -121,7 +121,7 @@ namespace Izzy_Moonbot
 
                 _client.Disconnected += async (Exception ex) =>
                 {
-                    Task.Run(async () =>
+                    var _ = Task.Run(async () =>
                     {
                         await Task.Delay(5000, stoppingToken);
                         if (_client.ConnectionState is ConnectionState.Disconnected or ConnectionState.Disconnecting)
@@ -159,11 +159,7 @@ namespace Izzy_Moonbot
 
         private async Task InstallCommandsAsync()
         {
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            _client.MessageReceived += async (message) => HandleMessageReceivedAsync(message);
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            _client.MessageReceived += async (message) => await DiscordHelper.LeakOrAwaitTask(HandleMessageReceivedAsync(message));
 
             await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services.BuildServiceProvider());
         }
@@ -213,7 +209,7 @@ namespace Izzy_Moonbot
                         _users.Add(socketGuildUser.Id, newUser);
                         
                         // Process new member
-                        _userListener.MemberJoinEvent(socketGuildUser, true);
+                        await _userListener.MemberJoinEvent(socketGuildUser, true);
                         
                         newUserCount += 1;
                         skip = true;

--- a/Izzy-MoonbotTests/Izzy-Moonbot-Tests.csproj
+++ b/Izzy-MoonbotTests/Izzy-Moonbot-Tests.csproj
@@ -9,6 +9,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1998</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1998</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />

--- a/Izzy-MoonbotTests/Service/LoggingServiceTests.cs
+++ b/Izzy-MoonbotTests/Service/LoggingServiceTests.cs
@@ -31,13 +31,13 @@ public class LoggingServiceTests
         var logger = new TestLogger<Worker>();
         var logService = new LoggingService(logger);
 
-        await logService.Log("test");
+        logService.Log("test");
         TestUtils.AssertListsAreEqual(new List<string> { "[LoggingServiceTests.cs:BasicTests:34] test" }, logger.Logs);
 
         var (_, _, (_, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "good morning everypony");
 
-        await logService.Log("sunny said something", context);
+        logService.Log("sunny said something", context);
         TestUtils.AssertListsAreEqual(new List<string> {
             $"[LoggingServiceTests.cs:BasicTests:34] test",
             $"[LoggingServiceTests.cs:BasicTests:40] server: Maretime Bay ({guild.Id}) #general ({generalChannel.Id}) @Sunny#1234 ({sunny.Id}), sunny said something"

--- a/Izzy-MoonbotTests/Service/TestAdapters.cs
+++ b/Izzy-MoonbotTests/Service/TestAdapters.cs
@@ -7,10 +7,6 @@ namespace Izzy_Moonbot.Adapters;
 // This file is for test implementations of the Discord.NET
 // adapter interfaces in IzzyInterfaces.cs.
 
-// Unfortunately CS1998 doesn't understand the concept of a synchronous implementation of
-// an asynchronous API, so there's no way to satisfy it without spawning useless threads.
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
 public class TestUser : IIzzyUser
 {
     public ulong Id { get; }


### PR DESCRIPTION
This takes us from 139 warnings to 104 warnings (edit: well the exact numbers change when we merge other PRs or rebase this one, but you get the idea).

While working on a PR to clean up all of our compiler warnings, I noticed and/or remembered that these two in particular caused headaches for us:

> warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.

> warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.

And how to resolve them is sufficiently non-obvious that I felt they were worth their own PR to check that you agree with my conclusions:

- IMO cs1998 is basically always wrong. We already disabled it for a whole file, but this PR elevates it to being disabled in both projects (apparently there is no solution-level warning config). While an async method that never awaits anything might seem odd in theory, this arises constantly for us in practice because of interfaces expecting a Task where our implementation happens to be fully synchronous, and using `async` is by far the most concise way to satisfy that return type.
- In contrast, cs4014 is fine to leave on, because everywhere it pointed out was a place where I really did need to stop and think about whether we should `await` or intentionally leak the task, and I think it's a net win to put a `var _ = ...` (or `LeakOrAwaitTask()`) on all of our intentional async leaks.
- `logger.Log()` has no reason to be async. I decided to make it sync and go delete all the existing `await`s on it, which accounts for most of the line count of this PR.