### PR TITLE
pass onEdit arg so filter modlogs say 'on message edit' when appropriate

### DIFF
--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -46,7 +46,7 @@ public class FilterService
     }
 
     private async Task LogFilterTrip(IIzzyContext context, string word, string category,
-        List<string> actionsTaken, bool onEdit = false, IIzzyMessage message = null)
+        List<string> actionsTaken, bool onEdit)
     {
         var embedBuilder = new EmbedBuilder()
             .WithTitle(":warning: Filter violation detected" + (onEdit ? " on message edit" : ""))
@@ -102,8 +102,7 @@ public class FilterService
             .Send();
     }
 
-    private async Task ProcessFilterTrip(IIzzyContext context, string word, string category,
-        bool onEdit = false)
+    private async Task ProcessFilterTrip(IIzzyContext context, string word, string category, bool onEdit)
     {
         var roleIds = context.Guild.GetUser(context.User.Id).Roles.Select(role => role.Id).ToList();
 
@@ -179,7 +178,7 @@ public class FilterService
                 if (context.Message.Content.ToLower().Contains(word.ToLower()))
                 {
                     // Filter Trip!
-                    await ProcessFilterTrip(context, word, category);
+                    await ProcessFilterTrip(context, word, category, true);
                     trip = true;
                 }
             }
@@ -214,7 +213,7 @@ public class FilterService
                 if (context.Message.Content.ToLower().Contains(word.ToLower()))
                 {
                     // Filter Trip!
-                    await ProcessFilterTrip(context, word, category);
+                    await ProcessFilterTrip(context, word, category, false);
                     trip = true;
                 }
             }


### PR DESCRIPTION
Doesn't get much simpler or lower-stakes than this: We had code to slightly alter a modlog's text based on whether it was caused by a message, or a message _edit_, but it never got used because we never passed the `onEdit` argument that code was expecting.

This seems like a good first test of our "bug fixes don't need review" policy. We technically did that earlier today, but Cloudburst was online, active and clearly approving of that change even if not formally reviewing it. This will be the first PR for which I don't ping Cloudburst at all, and will instead merge myself later.