### PR TITLE
tweak the unban embed so the user mention gets resolved

### DIFF
--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -276,9 +276,9 @@ public class ScheduleService
 
         var embed = new EmbedBuilder()
             .WithTitle(
-                $"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator} " : "")}<@{job.User}> ({job.User})")
+                $"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator} " : "")} ({job.User})")
             .WithColor(16737792)
-            .WithFooter("Gasp! Does this mean I can invite them to our next traditional unicorn sleepover?")
+            .WithDescription($"Gasp! Does this mean I can invite <@{job.User}> to our next traditional unicorn sleepover?")
             .Build();
         
         await _modLogging.CreateModLog(guild)


### PR DESCRIPTION
Apparently a "title" and a "footer" can't resolve mentions, but a "description" (or a "field value") can.

Before:
![image](https://user-images.githubusercontent.com/5285357/209175301-5937e133-1f98-44bf-811a-4f2ee77a2ef8.png)

After:
![image](https://user-images.githubusercontent.com/5285357/209175069-eb5ffbe1-fe70-48fb-bc6f-45cfa93906de.png)

