### PR TITLE
delete half-implemented .state command

### DIFF
--- a/Izzy-Moonbot/Modules/DevModule.cs
+++ b/Izzy-Moonbot/Modules/DevModule.cs
@@ -401,37 +401,4 @@ public class DevModule : ModuleBase<SocketCommandContext>
                 break;
         }
     }
-
-    [Summary("Submodule for viewing and modifying the realtime state of Izzy Moonbot")]
-    public class StateSubmodule : ModuleBase<SocketCommandContext>
-    {
-        private State _state;
-
-        public StateSubmodule(State state)
-        {
-            _state = state;
-        }
-
-        [Command("state")]
-        [Summary("State values")]
-        public async Task StateCommandAsync([Summary("State name")] string stateKey = "")
-        {
-            if (stateKey == "")
-            {
-                var stateKeys = typeof(State).GetProperties().Select(info => info.Name);
-                await ReplyAsync(
-                    $"Please provide a state to view the value of (`.state <state>`):{Environment.NewLine}```{Environment.NewLine}" +
-                    string.Join(", ", stateKeys) +
-                    $"{Environment.NewLine}```");
-            }
-        }
-
-        public static bool DoesStateExist<T>(string key) where T : State
-        {
-            var t = typeof(T);
-
-            if (t.GetProperty(key) == null) return false;
-            return true;
-        }
-    }
 }


### PR DESCRIPTION
It would take significant work to make this command useful, and we do so little with the state object that I don't think it's worth it anyway.

This stub finally become a nuisance today by causing https://github.com/Manechat/izzy-moonbot/pull/227 to list `.state` as a command regular users could supposedly run. It's always been ignored by `.help` in the past because it was in the dev module (yet it lacks the dev-only permission attribute).