### PR TITLE
deduplicate IdHaver definitions

### DIFF
--- a/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
+++ b/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
@@ -317,18 +317,6 @@ public class SocketGuildAdapter : IIzzyGuild
     }
 }
 
-public class IdHaver : IIzzyHasId
-{
-    public ulong Id { get; }
-    public IdHaver(ulong id) => Id = id;
-}
-
-public class CustomIdHaver : IIzzyHasCustomId
-{
-    public string CustomId { get; }
-    public CustomIdHaver(string id) => CustomId = id;
-}
-
 public class SocketMessageComponentAdapter : IIzzySocketMessageComponent
 {
     private SocketMessageComponent _component;

--- a/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
+++ b/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
@@ -118,6 +118,20 @@ public interface IIzzyGuild
     IIzzySocketTextChannel? GetTextChannel(ulong channelId);
 }
 
+public interface IIzzyHasId { ulong Id { get; } }
+public class IdHaver : IIzzyHasId
+{
+    public ulong Id { get; }
+    public IdHaver(ulong id) => Id = id;
+}
+
+public interface IIzzyHasCustomId { string CustomId { get; } }
+public class CustomIdHaver : IIzzyHasCustomId
+{
+    public string CustomId { get; }
+    public CustomIdHaver(string id) => CustomId = id;
+}
+
 public interface IIzzyClient
 {
     IIzzyUser CurrentUser { get; }
@@ -127,7 +141,6 @@ public interface IIzzyClient
 
     event Func<IIzzyMessage, IIzzyMessageChannel, Task> MessageUpdated;
 
-    public interface IIzzyHasCustomId { string CustomId { get; } }
     public interface IIzzySocketMessageComponent {
         IIzzyHasId User { get; }
         IIzzyHasId Message { get; }
@@ -136,7 +149,6 @@ public interface IIzzyClient
     }
     event Func<IIzzySocketMessageComponent, Task> ButtonExecuted;
 
-    public interface IIzzyHasId { ulong Id { get; } }
     event Func<IIzzyHasId, IIzzyHasId, Task> MessageDeleted;
 
     IIzzyContext MakeContext(IIzzyUserMessage message);

--- a/Izzy-MoonbotTests/Service/TestAdapters.cs
+++ b/Izzy-MoonbotTests/Service/TestAdapters.cs
@@ -439,18 +439,6 @@ public class TestIzzyContext : IIzzyContext
     }
 }
 
-public class IdHaver : IIzzyHasId
-{
-    public ulong Id { get; }
-    public IdHaver(ulong id) => Id = id;
-}
-
-public class CustomIdHaver : IIzzyHasCustomId
-{
-    public string CustomId { get; }
-    public CustomIdHaver(string id) => CustomId = id;
-}
-
 public class StubClient : IIzzyClient
 {
     public IIzzyUser CurrentUser { get => _currentUser; }


### PR DESCRIPTION
This is to clean up these warnings:

> Warning	CS0436	The type 'IdHaver' in 'C:\Users\ixrec\git\izzy-moonbot\Izzy-MoonbotTests\Service\TestAdapters.cs' conflicts with the imported type 'IdHaver' in 'Izzy-Moonbot, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'C:\Users\ixrec\git\izzy-moonbot\Izzy-MoonbotTests\Service\TestAdapters.cs'.	Izzy-Moonbot-Tests	C:\Users\ixrec\git\izzy-moonbot\Izzy-MoonbotTests\Service\TestAdapters.cs	522	Active

After all, we have no good reason to write two separate but identical definitions of these classes.