### PR TITLE
update ban test after unban embed tweak

### DIFF
--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -277,14 +277,14 @@ public class ScheduleService
 
         var embed = new EmbedBuilder()
             .WithTitle(
-                $"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator} " : "")} ({job.User})")
+                $"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator}" : "")} ({job.User})")
             .WithColor(16737792)
             .WithDescription($"Gasp! Does this mean I can invite <@{job.User}> to our next traditional unicorn sleepover?")
             .Build();
         
         await _modLogging.CreateModLog(guild)
             .SetEmbed(embed)
-            .SetFileLogContent($"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator} " : "")} ({job.User})")
+            .SetFileLogContent($"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator}" : "")} ({job.User})")
             .Send();
     }
 

--- a/Izzy-MoonbotTests/Service/AdminModuleTests.cs
+++ b/Izzy-MoonbotTests/Service/AdminModuleTests.cs
@@ -101,7 +101,7 @@ public class AdminModuleTests
         await ss.Unicycle(client);
 
         Assert.AreEqual(1, modChat.Messages.Last().Embeds.Count);
-        Assert.AreEqual("Unbanned Pipp#1234 <@4> (4)", modChat.Messages.Last().Embeds.Last().Title);
+        Assert.AreEqual("Unbanned Pipp#1234 (4)", modChat.Messages.Last().Embeds.Last().Title);
         TestUtils.AssertSetsAreEqual(new HashSet<ulong> { hitchId }, guild.BannedUserIds);
         Assert.AreEqual(1, ss.GetScheduledJobs().Count);
 
@@ -109,7 +109,7 @@ public class AdminModuleTests
         await ss.Unicycle(client);
 
         Assert.AreEqual(1, modChat.Messages.Last().Embeds.Count);
-        Assert.AreEqual("Unbanned Hitch#1234 <@5> (5)", modChat.Messages.Last().Embeds.Last().Title);
+        Assert.AreEqual("Unbanned Hitch#1234 (5)", modChat.Messages.Last().Embeds.Last().Title);
         TestUtils.AssertSetsAreEqual(new HashSet<ulong>(), guild.BannedUserIds);
         Assert.AreEqual(0, ss.GetScheduledJobs().Count);
 


### PR DESCRIPTION
https://github.com/Manechat/izzy-moonbot/pull/216 and https://github.com/Manechat/izzy-moonbot/pull/225 had what I like to call a "logical conflict". While they never touched the same line of code, and both passed their own CI runs, one of them added a test which the other affected the behavior of, so after both were merged `mane` CI failed and immediately emailed me (which is awesome). And I might as well clean up the odd-looking extra space in that embed while I'm here.