### PR TITLE
delete alternate names for .config categories

### DIFF
--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -253,29 +253,18 @@ public class ConfigDescriber
             case "core":
                 return ConfigItemCategory.Core;
             case "server":
-            case "guild":
                 return ConfigItemCategory.Server;
             case "moderation":
-            case "mod":
                 return ConfigItemCategory.Moderation;
             case "debug":
-            case "dev":
-            case "development":
                 return ConfigItemCategory.Debug;
             case "user":
                 return ConfigItemCategory.User;
             case "filter":
-            case "wordfilter":
-            case "word-filter":
                 return ConfigItemCategory.Filter;
             case "spam":
-            case "antispam":
-            case "anti-spam":
-            case "pressure":
                 return ConfigItemCategory.Spam;
             case "raid":
-            case "antiraid":
-            case "anti-raid":
                 return ConfigItemCategory.Raid;
             default:
                 return null;


### PR DESCRIPTION
After PRs like https://github.com/Manechat/izzy-moonbot/pull/207, these alternate names have gone from "sure, why not" to a unexpected source of confusion because e.g. I keep expecting `.config pressure` to output a list of config items with "pressure" in the name, not the entire spam category.

Before:
![image](https://user-images.githubusercontent.com/5285357/209487316-99f61f0e-815b-4c8f-8f94-d29087c70945.png)

After:
![image](https://user-images.githubusercontent.com/5285357/209487271-05ec6664-341f-4842-be05-c72e220a4a9e.png)
