### PR TITLE
treat warnings as errors

### DIFF
--- a/Izzy-Moonbot/Izzy-Moonbot.csproj
+++ b/Izzy-Moonbot/Izzy-Moonbot.csproj
@@ -7,9 +7,11 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
       <NoWarn>1701;1702;1998</NoWarn>
+      <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
       <NoWarn>1701;1702;1998</NoWarn>
+      <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Izzy-MoonbotTests/Izzy-Moonbot-Tests.csproj
+++ b/Izzy-MoonbotTests/Izzy-Moonbot-Tests.csproj
@@ -11,10 +11,12 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1998</NoWarn>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <NoWarn>1701;1702;1998</NoWarn>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After cleaning up all the warnings in the codebase, I believe that (aside from the one async warning we explicitly disabled) all of them were the sort of warning that we'd be better off treating as an error.

Unlike fixing the warnings, this change is blocked on Cloudburst's approval, because it might cause her feature branch to stop building (and nothing will be blocked on this anyway).