### PR TITLE
deduplicate all of our 'if >10 items, paginate them' blocks

### DIFF
--- a/Izzy-Moonbot/Helpers/PaginationHelper.cs
+++ b/Izzy-Moonbot/Helpers/PaginationHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord;
@@ -23,6 +24,30 @@ public class PaginationHelper
     public DateTime ExpiresAt;
     private int _pageNumber = 0;
     public string[] Pages;
+
+    public static void PaginateIfNeededAndSendMessage(IIzzyContext context, string header, IList<string> lineItems, string footer, uint pageSize = 10, AllowedMentions? allowedMentions = null)
+    {
+        if (lineItems.Count <= pageSize)
+        {
+            context.Channel.SendMessageAsync($"{header}\n{string.Join('\n', lineItems)}\n{footer}", allowedMentions: allowedMentions);
+            return;
+        }
+
+        var pages = new List<string>();
+        var pageNumber = -1;
+        for (var i = 0; i < lineItems.Count; i++)
+        {
+            if (i % pageSize == 0)
+            {
+                pageNumber += 1;
+                pages.Add("");
+            }
+
+            pages[pageNumber] += lineItems[i] + '\n';
+        }
+
+        new PaginationHelper(context, pages.ToArray(), new string[] { header, footer }, codeblock: false, allowedMentions: allowedMentions);
+    }
 
     public PaginationHelper(SocketCommandContext context, string[] pages, string[] staticParts,
         bool codeblock = true,

--- a/Izzy-Moonbot/Modules/ConfigCommand.cs
+++ b/Izzy-Moonbot/Modules/ConfigCommand.cs
@@ -68,39 +68,12 @@ public class ConfigCommand
 
                 var itemList = configDescriber.GetSettableConfigItemsByCategory(category);
 
-                if (itemList.Count > 10)
-                {
-                    // Use pagination
-                    var pages = new List<string>();
-                    var pageNumber = -1;
-                    for (var i = 0; i < itemList.Count; i++)
-                    {
-                        if (i % 10 == 0)
-                        {
-                            pageNumber += 1;
-                            pages.Add("");
-                        }
-
-                        pages[pageNumber] += itemList[i] + Environment.NewLine;
-                    }
-
-
-                    string[] staticParts =
-                    {
-                        $"Hii!! Here's a list of all the config items I could find in the {configDescriber.CategoryToString(category)} category!",
-                        $"Run `{config.Prefix}config <item>` to view information about an item! Please note that config items are *case sensitive*."
-                    };
-
-                    var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts);
-                }
-                else
-                {
-                    await context.Channel.SendMessageAsync(
-                        $"Hii!! Here's a list of all the config items I could find in the {configDescriber.CategoryToString(category)} category!" +
-                        $"{Environment.NewLine}```{Environment.NewLine}{string.Join(Environment.NewLine, itemList)}{Environment.NewLine}```{Environment.NewLine}" +
-                        $"Run `{config.Prefix}config <item>` to view information about an item! Please note that config items are *case sensitive*.");
-                }
-
+                PaginationHelper.PaginateIfNeededAndSendMessage(
+                    context,
+                    $"Hii!! Here's a list of all the config items I could find in the {configDescriber.CategoryToString(category)} category!\n```",
+                    itemList,
+                    $"```\nRun `{config.Prefix}config <item>` to view information about an item! Please note that config items are *case sensitive*."
+                );
                 return;
             }
         }
@@ -344,39 +317,13 @@ public class ConfigCommand
                                 return;
                             }
 
-                            if (stringSet.Count > 10)
-                            {
-                                // Use pagination
-                                var pages = new List<string>();
-                                var pageNumber = -1;
-                                var stringList = stringSet.OrderBy(x => x).ToList();
-                                for (var i = 0; i < stringList.Count; i++)
-                                {
-                                    if (i % 10 == 0)
-                                    {
-                                        pageNumber += 1;
-                                        pages.Add("");
-                                    }
-
-                                    pages[pageNumber] += stringList[i] + Environment.NewLine;
-                                }
-
-
-                                string[] staticParts =
-                                {
-                                    $"**{configItemKey}** contains the following values:",
-                                    ""
-                                };
-
-                                var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts);
-                            }
-                            else
-                            {
-                                await context.Channel.SendMessageAsync(
-                                    $"**{configItemKey}** contains the following values:{Environment.NewLine}```{Environment.NewLine}{string.Join(", ", stringSet)}{Environment.NewLine}```",
-                                    allowedMentions: AllowedMentions.None);
-                            }
-
+                            PaginationHelper.PaginateIfNeededAndSendMessage(
+                                context,
+                                $"**{configItemKey}** contains the following values:\n```",
+                                stringSet.OrderBy(x => x).ToList(),
+                                "```",
+                                allowedMentions: AllowedMentions.None
+                            );
                             break;
                         case ConfigItemType.RoleSet:
                             var roleSet = ConfigHelper.GetRoleSet(config, configItemKey, context);
@@ -384,39 +331,13 @@ public class ConfigCommand
                             var roleMentionList = new List<string>();
                             foreach (var role in roleSet) roleMentionList.Add(role.Mention);
 
-                            if (roleMentionList.Count > 10)
-                            {
-                                // Use pagination
-                                var pages = new List<string>();
-                                var pageNumber = -1;
-                                for (var i = 0; i < roleMentionList.Count; i++)
-                                {
-                                    if (i % 10 == 0)
-                                    {
-                                        pageNumber += 1;
-                                        pages.Add("");
-                                    }
-
-                                    pages[pageNumber] += roleMentionList[i] + Environment.NewLine;
-                                }
-
-
-                                string[] staticParts =
-                                {
-                                    $"**{configItemKey}** contains the following values:",
-                                    ""
-                                };
-
-                                var paginationMessage = new PaginationHelper(context, pages.ToArray(),
-                                    staticParts, false, AllowedMentions.None);
-                            }
-                            else
-                            {
-                                await context.Channel.SendMessageAsync(
-                                    $"**{configItemKey}** contains the following values:{Environment.NewLine}{string.Join(", ", roleMentionList)}",
-                                    allowedMentions: AllowedMentions.None);
-                            }
-
+                            PaginationHelper.PaginateIfNeededAndSendMessage(
+                                context,
+                                $"**{configItemKey}** contains the following values:",
+                                roleMentionList,
+                                "",
+                                allowedMentions: AllowedMentions.None
+                            );
                             break;
                         case ConfigItemType.ChannelSet:
                             var channelSet =
@@ -425,39 +346,13 @@ public class ConfigCommand
                             var channelMentionList = new List<string>();
                             foreach (var channel in channelSet) channelMentionList.Add($"<#{channel.Id}>");
 
-                            if (channelMentionList.Count > 10)
-                            {
-                                // Use pagination
-                                var pages = new List<string>();
-                                var pageNumber = -1;
-                                for (var i = 0; i < channelMentionList.Count; i++)
-                                {
-                                    if (i % 10 == 0)
-                                    {
-                                        pageNumber += 1;
-                                        pages.Add("");
-                                    }
-
-                                    pages[pageNumber] += channelMentionList[i] + Environment.NewLine;
-                                }
-
-
-                                string[] staticParts =
-                                {
-                                    $"**{configItemKey}** contains the following values:",
-                                    ""
-                                };
-
-                                var paginationMessage =
-                                    new PaginationHelper(context, pages.ToArray(), staticParts, false);
-                            }
-                            else
-                            {
-                                await context.Channel.SendMessageAsync(
-                                    $"**{configItemKey}** contains the following values:{Environment.NewLine}{string.Join(", ", channelMentionList)}",
-                                    allowedMentions: AllowedMentions.None);
-                            }
-
+                            PaginationHelper.PaginateIfNeededAndSendMessage(
+                                context,
+                                $"**{configItemKey}** contains the following values:",
+                                channelMentionList,
+                                "",
+                                allowedMentions: AllowedMentions.None
+                            );
                             break;
                         default:
                             await context.Channel.SendMessageAsync("I seem to have encountered a setting type that I do not know about.");
@@ -642,58 +537,16 @@ public class ConfigCommand
                         case ConfigItemType.StringDictionary:
                             try
                             {
-                                var keys = new List<string>();
-                                var values = new List<string?>();
-                                if (configItem.Nullable)
-                                {
-                                    keys = ConfigHelper
-                                        .GetDictionary<string?>(config, configItemKey)
-                                        .Keys.ToList();
-                                    values = ConfigHelper
-                                        .GetDictionary<string?>(config, configItemKey)
-                                        .Values.ToList();
-                                }
-                                else
-                                {
-                                    keys = ConfigHelper
-                                        .GetDictionary<string>(config, configItemKey)
-                                        .Keys.ToList();
-                                    values = ConfigHelper
-                                        .GetDictionary<string>(config, configItemKey)
-                                        .Values.Select(t => (string?)t).ToList();
-                                }
+                                IEnumerable<string> items = (configItem.Nullable) ?
+                                    ConfigHelper.GetDictionary<string?>(config, configItemKey).Select(kv => $"{kv.Key} = {kv.Value}") :
+                                    ConfigHelper.GetDictionary<string>(config, configItemKey).Select(kv => $"{kv.Key} = {kv.Value}");
 
-                                if (keys.Count > 10)
-                                {
-                                    // Use pagination
-                                    var pages = new List<string>();
-                                    var pageNumber = -1;
-                                    for (var i = 0; i < keys.Count; i++)
-                                    {
-                                        if (i % 10 == 0)
-                                        {
-                                            pageNumber += 1;
-                                            pages.Add("");
-                                        }
-
-                                        pages[pageNumber] += $"{keys[i]} = {values[i]}{Environment.NewLine}";
-                                    }
-
-                                    string[] staticParts =
-                                    {
-                                        $"**{configItemKey}** contains the following keys:",
-                                        ""
-                                    };
-
-                                    var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts);
-                                }
-                                else
-                                {
-                                    var listString = keys.Select((t, i) => $"{t} = {values[i]}").ToList();
-                                    
-                                    await context.Channel.SendMessageAsync(
-                                        $"**{configItemKey}** contains the following keys:{Environment.NewLine}```{Environment.NewLine}{string.Join($"{Environment.NewLine}", listString)}{Environment.NewLine}```");
-                                }
+                                PaginationHelper.PaginateIfNeededAndSendMessage(
+                                    context,
+                                    $"**{configItemKey}** contains the following keys:\n```",
+                                    items.ToList(),
+                                    $"```"
+                                );
                             }
                             catch (ArgumentOutOfRangeException ex)
                             {
@@ -873,49 +726,14 @@ public class ConfigCommand
                         case ConfigItemType.StringSetDictionary:
                             try
                             {
-                                var keys = ConfigHelper
-                                    .GetDictionary<HashSet<string>>(config, configItemKey).Keys
-                                    .ToList();
+                                var dict = ConfigHelper.GetDictionary<HashSet<string>>(config, configItemKey);
 
-                                var values = ConfigHelper
-                                    .GetDictionary<HashSet<string>>(config, configItemKey).Values
-                                    .ToList();
-
-                                if (keys.Count > 10)
-                                {
-                                    // Use pagination
-                                    var pages = new List<string>();
-                                    var pageNumber = -1;
-                                    for (var i = 0; i < keys.Count; i++)
-                                    {
-                                        if (i % 10 == 0)
-                                        {
-                                            pageNumber += 1;
-                                            pages.Add("");
-                                        }
-
-                                        pages[pageNumber] +=
-                                            $"{keys[i]} ({values[i].Count} entries){Environment.NewLine}";
-                                    }
-
-
-                                    string[] staticParts =
-                                    {
-                                        $"**{configItemKey}** contains the following keys:",
-                                        ""
-                                    };
-
-                                    var paginationMessage =
-                                        new PaginationHelper(context, pages.ToArray(), staticParts);
-                                }
-                                else
-                                {
-                                    var listString = keys.Select((t, i) =>
-                                        $"{t} ({values[i].Count} entries){Environment.NewLine}").ToList();
-
-                                    await context.Channel.SendMessageAsync(
-                                        $"**{configItemKey}** contains the following keys:{Environment.NewLine}```{Environment.NewLine}{string.Join($"{Environment.NewLine}", listString)}{Environment.NewLine}```");
-                                }
+                                PaginationHelper.PaginateIfNeededAndSendMessage(
+                                    context,
+                                    $"**{configItemKey}** contains the following keys:\n```",
+                                    dict.Select(kv => $"{kv.Key} ({kv.Value.Count} entries)\n").ToList(),
+                                    $"```"
+                                );
                             }
                             catch (ArgumentOutOfRangeException ex)
                             {
@@ -951,37 +769,13 @@ public class ConfigCommand
                                     ConfigHelper.GetDictionaryValue<HashSet<string>>(config, configItemKey,
                                         value);
 
-                                if (stringSet.Count > 10)
-                                {
-                                    // Use pagination
-                                    var pages = new List<string>();
-                                    var pageNumber = -1;
-                                    var stringList = stringSet.OrderBy(x => x).ToList();
-                                    for (var i = 0; i < stringList.Count; i++)
-                                    {
-                                        if (i % 10 == 0)
-                                        {
-                                            pageNumber += 1;
-                                            pages.Add("");
-                                        }
-
-                                        pages[pageNumber] += stringList[i] + Environment.NewLine;
-                                    }
-
-                                    string[] staticParts =
-                                    {
-                                        $"**{value}** contains the following values:",
-                                        ""
-                                    };
-
-                                    var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts);
-                                }
-                                else
-                                {
-                                    await context.Channel.SendMessageAsync(
-                                        $"**{value}** contains the following values:{Environment.NewLine}```{Environment.NewLine}{string.Join(", ", stringSet)}{Environment.NewLine}```",
-                                        allowedMentions: AllowedMentions.None);
-                                }
+                                PaginationHelper.PaginateIfNeededAndSendMessage(
+                                    context,
+                                    $"**{value}** contains the following values:\n```",
+                                    stringSet.OrderBy(x => x).ToList(),
+                                    $"```",
+                                    allowedMentions: AllowedMentions.None
+                                );
                             }
                             catch (KeyNotFoundException ex)
                             {

--- a/Izzy-Moonbot/Modules/MiscModule.cs
+++ b/Izzy-Moonbot/Modules/MiscModule.cs
@@ -361,45 +361,16 @@ public class MiscModule : ModuleBase<SocketCommandContext>
                 $"{prefix}{command.Name} - {command.Summary}"
             ).ToList();
 
-            if (commands.Count > 10)
-            {
-                // Use pagination
-                var pages = new List<string>();
-                var pageNumber = -1;
-                for (var i = 0; i < commands.Count; i++)
-                {
-                    if (i % 10 == 0)
-                    {
-                        pageNumber += 1;
-                        pages.Add("");
-                    }
+            var potentialAliases = _commands.Commands.Where(command =>
+                command.Aliases.Select(alias => alias.ToLower()).Contains(item.ToLower())).ToArray();
 
-                    pages[pageNumber] += commands[i] + Environment.NewLine;
-                }
-
-                var potentialAliases = _commands.Commands.Where(command =>
-                    command.Aliases.Select(alias => alias.ToLower()).Contains(item.ToLower())).ToArray();
-
-                string[] staticParts =
-                {
-                            $"Hii! Here's a list of all the commands I could find in the {moduleInfo.Name.Replace("Module", "")} category!",
-                            $"Run `{prefix}help <command>` for help regarding a specific command!" +
-                            $"{(potentialAliases.Length != 0 ? $"{Environment.NewLine}ℹ  This category shares a name with an alias. For information regarding this alias, run `{prefix}help {potentialAliases.First().Name.ToLower()}`.": "")}"
-                        };
-
-                var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts);
-            }
-            else
-            {
-                var potentialAliases = _commands.Commands.Where(command =>
-                    command.Aliases.Select(alias => alias.ToLower()).Contains(item.ToLower())).ToArray();
-
-                await context.Channel.SendMessageAsync(
-                    $"Hii! Here's a list of all the commands I could find in the {moduleInfo.Name.Replace("Module", "")} category!{Environment.NewLine}" +
-                    $"```{Environment.NewLine}{string.Join(Environment.NewLine, commands)}{Environment.NewLine}```{Environment.NewLine}" +
-                    $"Run `{prefix}help <command>` for help regarding a specific command!" +
-                    $"{(potentialAliases.Length != 0 ? $"{Environment.NewLine}ℹ  This category shares a name with an alias. For information regarding this alias, run `{prefix}help {potentialAliases.First().Name.ToLower()}`." : "")}");
-            }
+            PaginationHelper.PaginateIfNeededAndSendMessage(
+                context,
+                $"Hii! Here's a list of all the commands I could find in the {moduleInfo.Name.Replace("Module", "")} category!\n```",
+                commands,
+                $"Run `{prefix}help <command>` for help regarding a specific command!" +
+                $"{(potentialAliases.Length != 0 ? $"{Environment.NewLine}ℹ  This category shares a name with an alias. For information regarding this alias, run `{prefix}help {potentialAliases.First().Name.ToLower()}`." : "")}"
+            );
         }
         // Try alternate command names
         else if (_commands.Commands.Any(command =>

--- a/Izzy-Moonbot/Modules/ModMiscModule.cs
+++ b/Izzy-Moonbot/Modules/ModMiscModule.cs
@@ -383,38 +383,14 @@ public class ModMiscModule : ModuleBase<SocketCommandContext>
             {
                 // All
                 var jobs = _schedule.GetScheduledJobs().Select(job => job.ToDiscordString()).ToList();
-                if (jobs.Count > 10)
-                {
-                    // Use pagination
-                    var pages = new List<string>();
-                    var pageNumber = -1;
-                    for (var i = 0; i < jobs.Count; i++)
-                    {
-                        if (i % 10 == 0)
-                        {
-                            pageNumber += 1;
-                            pages.Add("");
-                        }
 
-                        pages[pageNumber] += $"{jobs[i]}\n";
-                    }
-
-                    string[] staticParts =
-                    {
-                        "Heya! Here's a list of all the scheduled jobs!",
-                        "If you need a raw text list, run `.schedule list-file`."
-                    };
-
-                    var paginationMessage =
-                        new PaginationHelper(context, pages.ToArray(), staticParts, codeblock: false, allowedMentions: AllowedMentions.None);
-                }
-                else
-                {
-                    await context.Channel.SendMessageAsync(
-                        $"Heya! Here's a list of all the scheduled jobs!\n\n" +
-                        string.Join(Environment.NewLine, jobs) +
-                        $"\n\nIf you need a raw text file, run `.schedule list-file`.", allowedMentions: AllowedMentions.None);
-                }
+                PaginationHelper.PaginateIfNeededAndSendMessage(
+                    context,
+                    "Heya! Here's a list of all the scheduled jobs!\n",
+                    jobs.Select(j => j.ToString()).ToList(),
+                    "\nIf you need a raw text file, run `.schedule list-file`.",
+                    allowedMentions: AllowedMentions.None
+                );
             }
             else
             {
@@ -429,38 +405,14 @@ public class ModMiscModule : ModuleBase<SocketCommandContext>
                 }
 
                 var jobs = _schedule.GetScheduledJobs().Where(job => job.Action.GetType().FullName == type.FullName).Select(job => job.ToDiscordString()).ToList();
-                if (jobs.Count > 10)
-                {
-                    // Use pagination
-                    var pages = new List<string>();
-                    var pageNumber = -1;
-                    for (var i = 0; i < jobs.Count; i++)
-                    {
-                        if (i % 10 == 0)
-                        {
-                            pageNumber += 1;
-                            pages.Add("");
-                        }
 
-                        pages[pageNumber] += $"{jobs[i]}\n";
-                    }
-
-                    string[] staticParts =
-                    {
-                        $"Heya! Here's a list of all the scheduled {jobType} jobs!",
-                        $"If you need a raw text list, run `.schedule list-file {jobType}`."
-                    };
-
-                    var paginationMessage =
-                        new PaginationHelper(context, pages.ToArray(), staticParts, codeblock: false, allowedMentions: AllowedMentions.None);
-                }
-                else
-                {
-                    await context.Channel.SendMessageAsync(
-                        $"Heya! Here's a list of all the scheduled {jobType} jobs!\n\n" +
-                        string.Join(Environment.NewLine, jobs) +
-                        $"\n\nIf you need a raw text list, run `.schedule list-file {jobType}`.", allowedMentions: AllowedMentions.None);
-                }
+                PaginationHelper.PaginateIfNeededAndSendMessage(
+                    context,
+                    $"Heya! Here's a list of all the scheduled {jobType} jobs!\n",
+                    jobs.Select(j => j.ToString()).ToList(),
+                    $"\nIf you need a raw text file, run `.schedule list-file {jobType}`.",
+                    allowedMentions: AllowedMentions.None
+                );
             }
         }
         else if (args.Arguments[0].ToLower() == "list-file")

--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord;
@@ -303,39 +304,15 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             // Show a list of list keys, paginating them if possible.
             var quoteKeys = _quoteService.GetKeyList(defaultGuild);
 
-            if (quoteKeys.Length > 15)
-            {
-                // Pagination
-                // Use pagination
-                var pages = new List<string>();
-                var pageNumber = -1;
-                for (var i = 0; i < quoteKeys.Length; i++)
-                {
-                    if (i % 15 == 0)
-                    {
-                        pageNumber += 1;
-                        pages.Add("");
-                    }
-
-                    pages[pageNumber] += quoteKeys[i] + Environment.NewLine;
-                }
-
-
-                string[] staticParts =
-                {
-                        $"Here's a list of users/categories of quotes I've found.",
-                        $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category if specified.{Environment.NewLine}" +
-                        $"Run `{_config.Prefix}quote` for a random quote from a random user/category."
-                    };
-
-                var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts, allowedMentions: AllowedMentions.None);
-                return;
-            }
-            // No pagination, just output
-            await context.Channel.SendMessageAsync($"Here's a list of users/categories of quotes I've found.{Environment.NewLine}```{Environment.NewLine}" +
-                             $"{string.Join(Environment.NewLine, quoteKeys)}{Environment.NewLine}```{Environment.NewLine}" +
-                             $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category if specified.{Environment.NewLine}" +
-                             $"Run `{_config.Prefix}quote` for a random quote from a random user/category.", allowedMentions: AllowedMentions.None);
+            PaginationHelper.PaginateIfNeededAndSendMessage(
+                context,
+                "Here's a list of users/categories of quotes I've found.\n```",
+                quoteKeys,
+                $"```\nRun `{_config.Prefix}quote <user/category>` to get a random quote from that user/category if specified.\n" +
+                $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                pageSize: 15,
+                allowedMentions: AllowedMentions.None
+            );
             return;
         }
 
@@ -348,46 +325,20 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                 // The alias refers to an existing user. 
                 var user = _quoteService.ProcessAlias(search, defaultGuild);
 
-                // Choose a random quote from this user.
                 try
                 {
                     var quotes = _quoteService.GetQuotes(user).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
 
-                    if (quotes.Length > 15)
-                    {
-                        // Pagination
-                        // Use pagination
-                        var pages = new List<string>();
-                        var pageNumber = -1;
-                        for (var i = 0; i < quotes.Length; i++)
-                        {
-                            if (i % 15 == 0)
-                            {
-                                pageNumber += 1;
-                                pages.Add("");
-                            }
-
-                            pages[pageNumber] += quotes[i] + Environment.NewLine;
-                        }
-
-
-                        string[] staticParts =
-                        {
-                                $"Here's all the quotes I could find for **{user.Username}#{user.Discriminator}**.",
-                                $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote` for a random quote from a random user/category."
-                            };
-
-                        var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts, allowedMentions: AllowedMentions.None);
-                        return;
-                    }
-                    // No pagination, just output
-                    await context.Channel.SendMessageAsync($"Here's all the quotes I could find for **{user.Username}#{user.Discriminator}**.{Environment.NewLine}```{Environment.NewLine}" +
-                                     $"{string.Join(Environment.NewLine, quotes)}{Environment.NewLine}```{Environment.NewLine}" +
-                                     $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                                     $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                                     $"Run `{_config.Prefix}quote` for a random quote from a random user/category.", allowedMentions: AllowedMentions.None);
+                    PaginationHelper.PaginateIfNeededAndSendMessage(
+                        context,
+                        $"Here's all the quotes I could find for **{user.Username}#{user.Discriminator}**.",
+                        quotes,
+                        $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
+                        $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
+                        $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                        pageSize: 15,
+                        allowedMentions: AllowedMentions.None
+                    );
                     return;
                 }
                 catch (NullReferenceException)
@@ -404,41 +355,16 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             {
                 var quotes = _quoteService.GetQuotes(category).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
 
-                if (quotes.Length > 15)
-                {
-                    // Pagination
-                    // Use pagination
-                    var pages = new List<string>();
-                    var pageNumber = -1;
-                    for (var i = 0; i < quotes.Length; i++)
-                    {
-                        if (i % 15 == 0)
-                        {
-                            pageNumber += 1;
-                            pages.Add("");
-                        }
-
-                        pages[pageNumber] += quotes[i] + Environment.NewLine;
-                    }
-
-
-                    string[] staticParts =
-                    {
-                                $"Here's all the quotes I could find in **{category}**.",
-                                $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote` for a random quote from a random user/category."
-                            };
-
-                    var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts, allowedMentions: AllowedMentions.None);
-                    return;
-                }
-                // No pagination, just output
-                await context.Channel.SendMessageAsync($"Here's all the quotes I could find in **{category}**.{Environment.NewLine}```{Environment.NewLine}" +
-                                 $"{string.Join(Environment.NewLine, quotes)}{Environment.NewLine}```{Environment.NewLine}" +
-                                 $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                                 $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                                 $"Run `{_config.Prefix}quote` for a random quote from a random user/category.", allowedMentions: AllowedMentions.None);
+                PaginationHelper.PaginateIfNeededAndSendMessage(
+                    context,
+                    $"Here's all the quotes I could find in **{category}**.",
+                    quotes,
+                    $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
+                    $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
+                    $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                    pageSize: 15,
+                    allowedMentions: AllowedMentions.None
+                );
                 return;
             }
             catch (NullReferenceException)
@@ -456,41 +382,16 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             {
                 var quotes = _quoteService.GetQuotes(search).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
 
-                if (quotes.Length > 15)
-                {
-                    // Pagination
-                    // Use pagination
-                    var pages = new List<string>();
-                    var pageNumber = -1;
-                    for (var i = 0; i < quotes.Length; i++)
-                    {
-                        if (i % 15 == 0)
-                        {
-                            pageNumber += 1;
-                            pages.Add("");
-                        }
-
-                        pages[pageNumber] += quotes[i] + Environment.NewLine;
-                    }
-
-
-                    string[] staticParts =
-                    {
-                                $"Here's all the quotes I could find in **{search}**.",
-                                $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote` for a random quote from a random user/category."
-                            };
-
-                    var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts, allowedMentions: AllowedMentions.None);
-                    return;
-                }
-                // No pagination, just output
-                await context.Channel.SendMessageAsync($"Here's all the quotes I could find in **{search}**.{Environment.NewLine}```{Environment.NewLine}" +
-                                 $"{string.Join(Environment.NewLine, quotes)}{Environment.NewLine}```{Environment.NewLine}" +
-                                 $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                                 $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                                 $"Run `{_config.Prefix}quote` for a random quote from a random user/category.", allowedMentions: AllowedMentions.None);
+                PaginationHelper.PaginateIfNeededAndSendMessage(
+                    context,
+                    $"Here's all the quotes I could find in **{search}**.",
+                    quotes,
+                    $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
+                    $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
+                    $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                    pageSize: 15,
+                    allowedMentions: AllowedMentions.None
+                );
                 return;
             }
             catch (NullReferenceException)
@@ -511,46 +412,20 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             return;
         }
 
-        // User exists, choose a random quote from this user.
         try
         {
             var quotes = _quoteService.GetQuotes(member).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
 
-            if (quotes.Length > 15)
-            {
-                // Pagination
-                // Use pagination
-                var pages = new List<string>();
-                var pageNumber = -1;
-                for (var i = 0; i < quotes.Length; i++)
-                {
-                    if (i % 15 == 0)
-                    {
-                        pageNumber += 1;
-                        pages.Add("");
-                    }
-
-                    pages[pageNumber] += quotes[i] + Environment.NewLine;
-                }
-
-
-                string[] staticParts =
-                {
-                                $"Here's all the quotes I could find for **{member.DisplayName}**.",
-                                $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                                $"Run `{_config.Prefix}quote` for a random quote from a random user/category."
-                            };
-
-                var paginationMessage = new PaginationHelper(context, pages.ToArray(), staticParts, allowedMentions: AllowedMentions.None);
-                return;
-            }
-            // No pagination, just output
-            await context.Channel.SendMessageAsync($"Here's all the quotes I could find for **{member.DisplayName}**.{Environment.NewLine}```{Environment.NewLine}" +
-                             $"{string.Join(Environment.NewLine, quotes)}{Environment.NewLine}```{Environment.NewLine}" +
-                             $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.{Environment.NewLine}" +
-                             $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.{Environment.NewLine}" +
-                             $"Run `{_config.Prefix}quote` for a random quote from a random user/category.", allowedMentions: AllowedMentions.None);
+            PaginationHelper.PaginateIfNeededAndSendMessage(
+                context,
+                $"Here's all the quotes I could find for **{member.DisplayName}**.\n```",
+                quotes,
+                $"```\nRun `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
+                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
+                $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                pageSize: 15,
+                allowedMentions: AllowedMentions.None
+            );
             return;
         }
         catch (NullReferenceException)

--- a/Izzy-MoonbotTests/Service/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Service/ConfigCommandTests.cs
@@ -160,7 +160,7 @@ public class ConfigCommandTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "MentionResponses");
         StringAssert.Contains(description, "the following values:");
-        StringAssert.Contains(description, $"```{Environment.NewLine}hello new friend!{Environment.NewLine}```");
+        StringAssert.Contains(description, $"```\nhello new friend!\n```");
 
         // StringDictionary
 
@@ -187,9 +187,9 @@ public class ConfigCommandTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Aliases");
         StringAssert.Contains(description, "the following keys:");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"moonlaser = addquote moon{Environment.NewLine}" +
-            $"echogeneral = echo <#1>{Environment.NewLine}" +
+        StringAssert.Contains(description, $"```\n" +
+            $"moonlaser = addquote moon\n" +
+            $"echogeneral = echo <#1>\n" +
             $"```");
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config Aliases get moonlaser");
@@ -232,11 +232,11 @@ public class ConfigCommandTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "FilteredWords");
         StringAssert.Contains(description, "the following keys:");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"slurs (2 entries){Environment.NewLine}" +
-            $"{Environment.NewLine}" +
-            $"links (1 entries){Environment.NewLine}" +
-            $"{Environment.NewLine}" +
+        StringAssert.Contains(description, $"```\n" +
+            $"slurs (2 entries)\n" +
+            $"\n" +
+            $"links (1 entries)\n" +
+            $"\n" +
             $"```");
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config FilteredWords get slurs");
@@ -248,8 +248,9 @@ public class ConfigCommandTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "**slurs** contains");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"mudpony, screwhead{Environment.NewLine}" +
+        StringAssert.Contains(description, $"```\n" +
+            $"mudpony\n" +
+            $"screwhead\n" +
             $"```");
     }
 

--- a/Izzy-MoonbotTests/Service/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Service/QuoteModuleTests.cs
@@ -73,10 +73,10 @@ public class QuoteModuleTests
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Here's a list of");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"Sunny (Sunny#1234) {Environment.NewLine}" +
-            $"Izzy Moonbot (Izzy Moonbot#1234) {Environment.NewLine}" +
-            $"```{Environment.NewLine}");
+        StringAssert.Contains(description, $"```\n" +
+            $"Sunny (Sunny#1234) \n" +
+            $"Izzy Moonbot (Izzy Moonbot#1234) \n" +
+            $"```\n");
         StringAssert.Contains(description, "Run `.quote <user/category>`");
         StringAssert.Contains(description, "Run `.quote`");
 
@@ -86,9 +86,9 @@ public class QuoteModuleTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, "for **Izzy Moonbot**");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"1: let's unicycle it{Environment.NewLine}" +
-            $"```{Environment.NewLine}");
+        StringAssert.Contains(description, $"```\n" +
+            $"1: let's unicycle it\n" +
+            $"```\n");
         StringAssert.Contains(description, "Run `.quote <user/category> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user/category>` to");
         StringAssert.Contains(description, "Run `.quote` for");
@@ -99,10 +99,10 @@ public class QuoteModuleTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, "for **Sunny**");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"1: gonna be my day{Environment.NewLine}" +
-            $"2: eat more vegetables{Environment.NewLine}" +
-            $"```{Environment.NewLine}");
+        StringAssert.Contains(description, $"```\n" +
+            $"1: gonna be my day\n" +
+            $"2: eat more vegetables\n" +
+            $"```\n");
         StringAssert.Contains(description, "Run `.quote <user/category> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user/category>` to");
         StringAssert.Contains(description, "Run `.quote` for");
@@ -137,9 +137,9 @@ public class QuoteModuleTests
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Here's a list of");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"1234 {Environment.NewLine}" +
-            $"```{Environment.NewLine}");
+        StringAssert.Contains(description, $"```\n" +
+            $"1234 \n" +
+            $"```\n");
         StringAssert.Contains(description, "Run `.quote <user/category>`");
         StringAssert.Contains(description, "Run `.quote`");
     }
@@ -164,10 +164,10 @@ public class QuoteModuleTests
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, "for **Sunny**");
-        StringAssert.Contains(description, $"```{Environment.NewLine}" +
-            $"1: gonna be my day{Environment.NewLine}" +
-            $"2: gonna be my day{Environment.NewLine}" +
-            $"```{Environment.NewLine}");
+        StringAssert.Contains(description, $"```\n" +
+            $"1: gonna be my day\n" +
+            $"2: gonna be my day\n" +
+            $"```\n");
         StringAssert.Contains(description, "Run `.quote <user/category> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user/category>` to");
         StringAssert.Contains(description, "Run `.quote` for");


### PR DESCRIPTION
Aside from making a lot of things more concise, this also fixes several subtle inconsistencies, such as `AllowedMentions.None` often being applied only to the un-paginated version of a message.