### PR TITLE
ScheduledEchoJob has a ChannelOrUser, not necessarily a Channel

### DIFF
--- a/Izzy-Moonbot/EventListeners/UserListener.cs
+++ b/Izzy-Moonbot/EventListeners/UserListener.cs
@@ -258,7 +258,7 @@ public class UserListener
             job.Action switch
             {
                 ScheduledRoleJob roleJob => roleJob.User == user.Id,
-                ScheduledEchoJob echoJob => echoJob.Channel == user.Id,
+                ScheduledEchoJob echoJob => echoJob.ChannelOrUser == user.Id,
                 _ => false
             }
         );

--- a/Izzy-Moonbot/Modules/ModMiscModule.cs
+++ b/Izzy-Moonbot/Modules/ModMiscModule.cs
@@ -518,7 +518,7 @@ public class ModMiscModule : ModuleBase<SocketCommandContext>
                                                 $"Target role: <@&{roleJob.Role}>\n" +
                                                 $"{(roleJob.Reason != null ? $"Reason: {roleJob.Reason}\n" : "")}",
                     ScheduledUnbanJob unbanJob => $"Target user: <@{unbanJob.User}>\n",
-                    ScheduledEchoJob echoJob => $"Target channel/user: <#{echoJob.Channel}> / <@{echoJob.Channel}>\n" +
+                    ScheduledEchoJob echoJob => $"Target channel/user: <#{echoJob.ChannelOrUser}> / <@{echoJob.ChannelOrUser}>\n" +
                                                 $"Content:\n```\n{echoJob.Content}\n```\n",
                     ScheduledBannerRotationJob => $"Current banner mode: {_config.BannerMode}\n" +
                                                   $"Configure this job via `.config`.\n",

--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -288,10 +288,10 @@ public class ScheduleService
     private async Task Unicycle_Echo(ScheduledEchoJob job, IIzzyGuild guild, IIzzyClient client)
     {
         if (job.Content == "") return;
-        var channel = guild.GetTextChannel(job.Channel);
+        var channel = guild.GetTextChannel(job.ChannelOrUser);
         if (channel == null)
         {
-            await client.SendDirectMessageAsync(job.Channel, job.Content);
+            await client.SendDirectMessageAsync(job.ChannelOrUser, job.Content);
             return;
         }
 

--- a/Izzy-Moonbot/Types/ScheduledJob.cs
+++ b/Izzy-Moonbot/Types/ScheduledJob.cs
@@ -154,41 +154,41 @@ public class ScheduledUnbanJob : ScheduledJobAction
 
 public class ScheduledEchoJob : ScheduledJobAction
 {
-    public ScheduledEchoJob(ulong channel, string content)
+    public ScheduledEchoJob(ulong channelOrUser, string content)
     {
         Type = ScheduledJobActionType.Echo;
-        
-        Channel = channel;
+
+        ChannelOrUser = channelOrUser;
         Content = content;
     }
 
     public ScheduledEchoJob(IIzzyMessageChannel channel, string content)
     {
         Type = ScheduledJobActionType.Echo;
-        
-        Channel = channel.Id;
+
+        ChannelOrUser = channel.Id;
         Content = content;
     }
 
     public ScheduledEchoJob(IIzzyUser user, string content)
     {
         Type = ScheduledJobActionType.Echo;
-        
-        Channel = user.Id;
+
+        ChannelOrUser = user.Id;
         Content = content;
     }
     
-    public ulong Channel { get; }
+    public ulong ChannelOrUser { get; }
     public string Content { get; }
     
     public override string ToDiscordString()
     {
-        return $"Send \"{Content}\" to <#{Channel}> (`{Channel}`)";
+        return $"Send \"{Content}\" to (<#{ChannelOrUser}>/<@{ChannelOrUser}>) (`{ChannelOrUser}`)";
     }
     
     public override string ToFileString()
     {
-        return $"Send \"{Content}\" to channel/user {Channel}";
+        return $"Send \"{Content}\" to channel/user {ChannelOrUser}";
     }
 }
 

--- a/Izzy-MoonbotTests/Service/ModMiscModuleTests.cs
+++ b/Izzy-MoonbotTests/Service/ModMiscModuleTests.cs
@@ -97,7 +97,7 @@ public class ModMiscModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Here's a list of all the scheduled jobs!");
-        StringAssert.Contains(description, $": Send \"this is a test\" to <#{sunny.Id}> (`{sunny.Id}`) <t:1286669400:R>.");
+        StringAssert.Contains(description, $": Send \"this is a test\" to (<#{sunny.Id}>/<@{sunny.Id}>) (`{sunny.Id}`) <t:1286669400:R>.");
         StringAssert.Contains(description, "If you need a raw text file");
         Assert.AreEqual(1, ss.GetScheduledJobs().Count());
         var job = ss.GetScheduledJobs().Last();
@@ -105,7 +105,7 @@ public class ModMiscModuleTests
         Assert.AreEqual(TestUtils.FiMEpoch.AddMinutes(10), job.ExecuteAt);
         Assert.AreEqual(ScheduledJobRepeatType.None, job.RepeatType);
         Assert.AreEqual(ScheduledJobActionType.Echo, job.Action.Type);
-        Assert.AreEqual(sunny.Id, (job.Action as ScheduledEchoJob)?.Channel);
+        Assert.AreEqual(sunny.Id, (job.Action as ScheduledEchoJob)?.ChannelOrUser);
         Assert.AreEqual("this is a test", (job.Action as ScheduledEchoJob)?.Content);
 
 
@@ -114,14 +114,14 @@ public class ModMiscModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Created scheduled job:");
-        StringAssert.Contains(description, $"Send \"this is another test\" to <#{generalChannel.Id}> (`{generalChannel.Id}`) <t:1286672400:R>");
+        StringAssert.Contains(description, $"Send \"this is another test\" to (<#{generalChannel.Id}>/<@{generalChannel.Id}>) (`{generalChannel.Id}`) <t:1286672400:R>");
         Assert.AreEqual(2, ss.GetScheduledJobs().Count());
         job = ss.GetScheduledJobs().Last();
         Assert.AreEqual(TestUtils.FiMEpoch, job.CreatedAt);
         Assert.AreEqual(TestUtils.FiMEpoch.AddHours(1), job.ExecuteAt);
         Assert.AreEqual(ScheduledJobRepeatType.None, job.RepeatType);
         Assert.AreEqual(ScheduledJobActionType.Echo, job.Action.Type);
-        Assert.AreEqual(generalChannel.Id, (job.Action as ScheduledEchoJob)?.Channel);
+        Assert.AreEqual(generalChannel.Id, (job.Action as ScheduledEchoJob)?.ChannelOrUser);
         Assert.AreEqual("this is another test", (job.Action as ScheduledEchoJob)?.Content);
     }
 
@@ -186,11 +186,11 @@ public class ModMiscModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Created scheduled job:");
-        StringAssert.Contains(description, $"Send \"hello there\" to <#{generalChannel.Id}> (`{generalChannel.Id}`) <t:1286672400:R>");
+        StringAssert.Contains(description, $"Send \"hello there\" to (<#{generalChannel.Id}>/<@{generalChannel.Id}>) (`{generalChannel.Id}`) <t:1286672400:R>");
         job = ss.GetScheduledJobs().Last();
         Assert.AreEqual(TestUtils.FiMEpoch.AddHours(1), job.ExecuteAt);
         Assert.AreEqual(ScheduledJobActionType.Echo, job.Action.Type);
-        Assert.AreEqual(generalChannel.Id, (job.Action as ScheduledEchoJob)?.Channel);
+        Assert.AreEqual(generalChannel.Id, (job.Action as ScheduledEchoJob)?.ChannelOrUser);
         Assert.AreEqual("hello there", (job.Action as ScheduledEchoJob)?.Content);
     }
 
@@ -210,7 +210,7 @@ public class ModMiscModuleTests
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Created scheduled job:");
-        StringAssert.Contains(description, $"Send \"do the pony ony ony\" to <#{generalChannel.Id}> (`{generalChannel.Id}`) <t:1286668810:R>, repeating Relative.");
+        StringAssert.Contains(description, $"Send \"do the pony ony ony\" to (<#{generalChannel.Id}>/<@{generalChannel.Id}>) (`{generalChannel.Id}`) <t:1286668810:R>, repeating Relative.");
         Assert.AreEqual(1, ss.GetScheduledJobs().Count());
         Assert.AreEqual(2, generalChannel.Messages.Count);
 


### PR DESCRIPTION
In particular, print both `<@id>` and `<#id>` in the .schedule output so that even though one will always fail, we will at least see the resolved thing it will echo to.