### PR TITLE
reintroduce the codeblock arg for pagination

### DIFF
--- a/Izzy-Moonbot/Helpers/PaginationHelper.cs
+++ b/Izzy-Moonbot/Helpers/PaginationHelper.cs
@@ -25,11 +25,17 @@ public class PaginationHelper
     private int _pageNumber = 0;
     public string[] Pages;
 
-    public static void PaginateIfNeededAndSendMessage(IIzzyContext context, string header, IList<string> lineItems, string footer, uint pageSize = 10, AllowedMentions? allowedMentions = null)
+    public static void PaginateIfNeededAndSendMessage(IIzzyContext context, string header, IList<string> lineItems, string footer, bool codeblock = true, uint pageSize = 10, AllowedMentions? allowedMentions = null)
     {
         if (lineItems.Count <= pageSize)
         {
-            context.Channel.SendMessageAsync($"{header}\n{string.Join('\n', lineItems)}\n{footer}", allowedMentions: allowedMentions);
+            context.Channel.SendMessageAsync(
+                $"{header}\n" +
+                (codeblock ? "```\n" : "") +
+                $"{string.Join('\n', lineItems)}" +
+                (codeblock ? "\n```" : "") +
+                $"\n{footer}",
+                allowedMentions: allowedMentions);
             return;
         }
 
@@ -46,7 +52,7 @@ public class PaginationHelper
             pages[pageNumber] += lineItems[i] + '\n';
         }
 
-        new PaginationHelper(context, pages.ToArray(), new string[] { header, footer }, codeblock: false, allowedMentions: allowedMentions);
+        new PaginationHelper(context, pages.ToArray(), new string[] { header, footer }, codeblock: codeblock, allowedMentions: allowedMentions);
     }
 
     public PaginationHelper(SocketCommandContext context, string[] pages, string[] staticParts,

--- a/Izzy-Moonbot/Modules/ConfigCommand.cs
+++ b/Izzy-Moonbot/Modules/ConfigCommand.cs
@@ -70,9 +70,9 @@ public class ConfigCommand
 
                 PaginationHelper.PaginateIfNeededAndSendMessage(
                     context,
-                    $"Hii!! Here's a list of all the config items I could find in the {configDescriber.CategoryToString(category)} category!\n```",
+                    $"Hii!! Here's a list of all the config items I could find in the {configDescriber.CategoryToString(category)} category!",
                     itemList,
-                    $"```\nRun `{config.Prefix}config <item>` to view information about an item! Please note that config items are *case sensitive*."
+                    $"Run `{config.Prefix}config <item>` to view information about an item! Please note that config items are *case sensitive*."
                 );
                 return;
             }
@@ -319,9 +319,9 @@ public class ConfigCommand
 
                             PaginationHelper.PaginateIfNeededAndSendMessage(
                                 context,
-                                $"**{configItemKey}** contains the following values:\n```",
+                                $"**{configItemKey}** contains the following values:",
                                 stringSet.OrderBy(x => x).ToList(),
-                                "```",
+                                "",
                                 allowedMentions: AllowedMentions.None
                             );
                             break;
@@ -543,9 +543,9 @@ public class ConfigCommand
 
                                 PaginationHelper.PaginateIfNeededAndSendMessage(
                                     context,
-                                    $"**{configItemKey}** contains the following keys:\n```",
+                                    $"**{configItemKey}** contains the following keys:",
                                     items.ToList(),
-                                    $"```"
+                                    $""
                                 );
                             }
                             catch (ArgumentOutOfRangeException ex)
@@ -730,9 +730,9 @@ public class ConfigCommand
 
                                 PaginationHelper.PaginateIfNeededAndSendMessage(
                                     context,
-                                    $"**{configItemKey}** contains the following keys:\n```",
+                                    $"**{configItemKey}** contains the following keys:",
                                     dict.Select(kv => $"{kv.Key} ({kv.Value.Count} entries)\n").ToList(),
-                                    $"```"
+                                    $""
                                 );
                             }
                             catch (ArgumentOutOfRangeException ex)
@@ -771,9 +771,9 @@ public class ConfigCommand
 
                                 PaginationHelper.PaginateIfNeededAndSendMessage(
                                     context,
-                                    $"**{value}** contains the following values:\n```",
+                                    $"**{value}** contains the following values:",
                                     stringSet.OrderBy(x => x).ToList(),
-                                    $"```",
+                                    $"",
                                     allowedMentions: AllowedMentions.None
                                 );
                             }

--- a/Izzy-Moonbot/Modules/MiscModule.cs
+++ b/Izzy-Moonbot/Modules/MiscModule.cs
@@ -332,7 +332,7 @@ public class MiscModule : ModuleBase<SocketCommandContext>
 
             PaginationHelper.PaginateIfNeededAndSendMessage(
                 context,
-                $"Hii! Here's a list of all the commands I could find in the {moduleInfo.Name.Replace("Module", "")} category!\n```",
+                $"Hii! Here's a list of all the commands I could find in the {moduleInfo.Name.Replace("Module", "")} category!",
                 commands,
                 $"Run `{prefix}help <command>` for help regarding a specific command!" +
                 $"{(potentialAliases.Length != 0 ? $"{Environment.NewLine}ℹ  This category shares a name with an alias. For information regarding this alias, run `{prefix}help {potentialAliases.First().Name.ToLower()}`." : "")}"

--- a/Izzy-Moonbot/Modules/ModMiscModule.cs
+++ b/Izzy-Moonbot/Modules/ModMiscModule.cs
@@ -390,6 +390,7 @@ public class ModMiscModule : ModuleBase<SocketCommandContext>
                     "Heya! Here's a list of all the scheduled jobs!\n",
                     jobs.Select(j => j.ToString()).ToList(),
                     "\nIf you need a raw text file, run `.schedule list-file`.",
+                    codeblock: false,
                     allowedMentions: AllowedMentions.None
                 );
             }
@@ -412,6 +413,7 @@ public class ModMiscModule : ModuleBase<SocketCommandContext>
                     $"Heya! Here's a list of all the scheduled {jobType} jobs!\n",
                     jobs.Select(j => j.ToString()).ToList(),
                     $"\nIf you need a raw text file, run `.schedule list-file {jobType}`.",
+                    codeblock: false,
                     allowedMentions: AllowedMentions.None
                 );
             }

--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -306,9 +306,9 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
             PaginationHelper.PaginateIfNeededAndSendMessage(
                 context,
-                "Here's a list of users/categories of quotes I've found.\n```",
+                "Here's a list of users/categories of quotes I've found.",
                 quoteKeys,
-                $"```\nRun `{_config.Prefix}quote <user/category>` to get a random quote from that user/category if specified.\n" +
+                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category if specified.\n" +
                 $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
                 pageSize: 15,
                 allowedMentions: AllowedMentions.None
@@ -418,9 +418,9 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
             PaginationHelper.PaginateIfNeededAndSendMessage(
                 context,
-                $"Here's all the quotes I could find for **{member.DisplayName}**.\n```",
+                $"Here's all the quotes I could find for **{member.DisplayName}**.",
                 quotes,
-                $"```\nRun `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
+                $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
                 $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
                 $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
                 pageSize: 15,


### PR DESCRIPTION
Closes #254

During https://github.com/Manechat/izzy-moonbot/pull/249 I thought the `codeblock` argument could be and had been made redundant by simply putting more \ns and `s into the header and footer strings. I now realize I misunderstood what this flag was doing and we really do need it after all. For example, there's a "page 1 out of 10" indicator between the page and the footer which we do not want to be inside the codeblock. So this goes back to the pre- #249 behavior, fixing some inconsistencies I accidentally introduced there.