### PR TITLE
pass only the Gateway Intents we use, not GatewayIntents.All

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -66,7 +66,10 @@ namespace Izzy_Moonbot
             _spamService = spamService;
             _configListener = configListener;
 
-            var discordConfig = new DiscordSocketConfig { GatewayIntents = GatewayIntents.All, MessageCacheSize = 50 };
+            var discordConfig = new DiscordSocketConfig {
+                GatewayIntents = GatewayIntents.Guilds | GatewayIntents.GuildMembers | GatewayIntents.GuildMessages | GatewayIntents.DirectMessages,
+                MessageCacheSize = 50
+            };
             _client = new DiscordSocketClient(discordConfig);
         }
 


### PR DESCRIPTION
Not terribly important, but we see these warnings every single time we run Izzy:

![image](https://user-images.githubusercontent.com/5285357/210036457-b334b3b3-166d-43ce-93fe-61b2421a813b.png)

And it's a very easy fix.

![image](https://user-images.githubusercontent.com/5285357/210036493-18414b43-c59b-44fc-9e25-e848b25264ad.png)

On this fixed branch, I also triggered the filter, and ran .lq moon to fiddle with the pagination.