### PR TITLE
date parsing refinements

### DIFF
--- a/Izzy-MoonbotTests/Service/TimeHelperTests.cs
+++ b/Izzy-MoonbotTests/Service/TimeHelperTests.cs
@@ -93,7 +93,7 @@ public class TimeHelperTests
         Assert.IsNull(TimeHelper.TryParseDateTime("one hour", out err));
         Assert.IsNotNull(err);
         StringAssert.Contains(err, "\"one\"");
-        StringAssert.Contains(err, "not a positive integer");
+        StringAssert.Contains(err, "extract a weekday + time"); // without the 'in', this gets mistaken for an attempted weekday
 
         Assert.IsNull(TimeHelper.TryParseDateTime("in 1 xyz", out err));
         Assert.IsNotNull(err);
@@ -321,6 +321,16 @@ public class TimeHelperTests
             new DateTimeOffset(2011, 1, 1, 12, 0, 0, TimeSpan.Zero), "yearly", ""
         );
         Assert.AreEqual(err, null);
+
+        Assert.IsNull(TimeHelper.TryParseDateTime("every 1 jan 2020 12:00", out err));
+        Assert.IsNotNull(err);
+        StringAssert.Contains(err, "\"every 1 jan 2020 12:00\"");
+        StringAssert.Contains(err, "\"2020\" is not a valid time");
+
+        Assert.IsNull(TimeHelper.TryParseDateTime("every 1 jan 12:00", out err));
+        Assert.IsNotNull(err);
+        StringAssert.Contains(err, "\"every 1 jan 12:00\"");
+        StringAssert.Contains(err, "missing a UTC offset");
     }
 
     [TestMethod()]


### PR DESCRIPTION
See the commit names for details.

Closes #266

For the "educated guesswork" part, before:
![image](https://user-images.githubusercontent.com/5285357/210115877-2c1141f7-9bc4-4d25-a085-d8b5cfbfb39c.png)

After:
![image](https://user-images.githubusercontent.com/5285357/210116247-73be406e-f5dc-4cb9-93e8-cc3ee9fef25c.png)
