### PR TITLE
CI Updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,7 @@
 **/bin
 **/charts
 **/docker-compose*
-**/Dockerfile*
+# **/Dockerfile*
 **/node_modules
 **/npm-debug.log
 **/obj

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -1,8 +1,6 @@
 name: Docker Image CI
 
 on:
-  pull_request:
-    types: [ closed ]
   push:
     branches: [ "mane" ]
   workflow_dispatch:
@@ -12,7 +10,7 @@ jobs:
   build-and-publish:
 
     runs-on: ubuntu-22.04
-    if: ${{ github.event.pull_request.merged == true || github.event_name == 'push' && github.ref_name == 'mane' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'push' && github.ref_name == 'mane' || github.event_name == 'workflow_dispatch' }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Remove redundant action trigger causing actions to fire twice on PR merge, and remove Dockerfile from .dockerignore for buildx compatibility.