### PR TITLE
revert Discord.NET back to v3.7.2

### DIFF
--- a/Izzy-Moonbot/Izzy-Moonbot.csproj
+++ b/Izzy-Moonbot/Izzy-Moonbot.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Discord.Net" Version="3.9.0" />
+        <PackageReference Include="Discord.Net" Version="3.7.2" />
         <PackageReference Include="Flurl.Http" Version="3.2.4" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />


### PR DESCRIPTION
For some reason, upgrading to v3.9 causes MessageReceived events to have completely blank content, which leads to all of Izzy's commands not working.

More specifically, when I put a breakpoint at the top of Worker.cs's `HandleMessageReceivedAsync()` and use the debugger to print the value of `messageParam`, I get this:
```
Ixrec⁩#7992:  (1059495347270996039)
    Activity: null
    Application: null
    Attachments: Length = 0
    Author: Ixrec#7992 (283037539755884554, Guild)
    Channel: general (963788928702373918, Text)
    CleanContent: ""
    Components: Length = 0
    Content: ""
    CreatedAt: {02/01/2023 15:36:15 +00:00}
    EditedTimestamp: null
    Embeds: Length = 0
    Flags: None
    Id: 1059495347270996039
    Interaction: null
    IsPinned: false
    IsSuppressed: false
    IsTTS: false
    MentionedChannels: Length = 0
    MentionedEveryone: false
    MentionedRoles: Length = 0
    MentionedUsers: Length = 0
    Reactions: Count = 0
    Reference: null
    ReferencedMessage: null
    Source: User
    Stickers: Length = 0
    Tags: Length = 0
    Timestamp: {02/01/2023 15:36:15 +00:00}
    Type: Default
```