### PR TITLE
update Discord.NET to v3.9 and start passing the MessageContent intent

### DIFF
--- a/Izzy-Moonbot/Izzy-Moonbot.csproj
+++ b/Izzy-Moonbot/Izzy-Moonbot.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Discord.Net" Version="3.7.2" />
+        <PackageReference Include="Discord.Net" Version="3.9.0" />
         <PackageReference Include="Flurl.Http" Version="3.2.4" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />

--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -67,7 +67,7 @@ namespace Izzy_Moonbot
             _configListener = configListener;
 
             var discordConfig = new DiscordSocketConfig {
-                GatewayIntents = GatewayIntents.Guilds | GatewayIntents.GuildMembers | GatewayIntents.GuildMessages | GatewayIntents.DirectMessages,
+                GatewayIntents = GatewayIntents.Guilds | GatewayIntents.GuildMembers | GatewayIntents.GuildMessages | GatewayIntents.DirectMessages | GatewayIntents.MessageContent,
                 MessageCacheSize = 50
             };
             _client = new DiscordSocketClient(discordConfig);


### PR DESCRIPTION
This intent wasn't in the library before the upgrade, and the upgrade breaks Izzy completely without it, so both of these changes must be done together.