### PR TITLE
Update Docker build action

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -26,15 +26,20 @@ jobs:
       with:
         buildkitd-flags: --debug
 
-    - name: Build the Docker image
-      run: docker buildx build . --file ./Izzy-Moonbot/Dockerfile --tag ghcr.io/manechat/izzy-moonbot:latest --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg BUILD_COMMIT=$GITHUB_SHA --platform linux/arm64
-
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v2.1.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push image to registry
-      run: docker push ghcr.io/manechat/izzy-moonbot:latest
+    - name: Build and push
+      uses: docker/build-push-action@v3.2.0
+      with:
+        context: "{{defaultContext}}:Izzy-Moonbot"
+        push: true
+        tags: ghcr.io/manechat/izzy-moonbot:latest
+        build-args: |
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          BUILD_COMMIT=$GITHUB_SHA
+        platforms: linux/arm64


### PR DESCRIPTION
Change from direct run command to Docker provided buildkit build-push action because of Buildkit/buildx quirks; move build-push after registry login; update login action to 2.1.0