### PR TITLE
don't start unicycling until we've resynced all users

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -184,8 +184,6 @@ namespace Izzy_Moonbot
                                  $"Unobserved Exception Stack: {unobservedException?.StackTrace}");
             };
 
-            _scheduleService.BeginUnicycleLoop(new DiscordSocketClientAdapter(_client));
-
             foreach (var clientGuild in _client.Guilds)
             {
                 _logger.LogDebug($"ReadyEvent() downloading users for guild {clientGuild.Name} ({clientGuild.Id})");
@@ -195,7 +193,8 @@ namespace Izzy_Moonbot
             _logger.LogDebug("ReadyEvent() resyncing users");
             ResyncUsers();
 
-            _logger.LogDebug("ReadyEvent() completed");
+            _logger.LogDebug("ReadyEvent() starting unicycle loop");
+            _scheduleService.BeginUnicycleLoop(new DiscordSocketClientAdapter(_client));
         }
 
         private void ResyncUsers()


### PR DESCRIPTION
ResyncUsers creates scheduled jobs like NP role removal, and most of Izzy's code assumes user information has already been populated so it's kinda risky to start executing any of these jobs before ResyncUsers is done. This has never been a problem in practice because none of the scheduled job implementations happen to even transitively access `_users`, but that could easily change in the future (e.g. Add/RemoveRoles don't touch `_users` but SilenceUsers does).

Noticed this when looking into a weird crash @LunarNightShade had while testing Portainer, though that specific crash's root cause was config missing critical roles.