### PR TITLE
ignore non-content message update in MessageListener and FilterService

### DIFF
--- a/Izzy-Moonbot/EventListeners/MessageListener.cs
+++ b/Izzy-Moonbot/EventListeners/MessageListener.cs
@@ -51,6 +51,13 @@ public class MessageListener
             return;
         }
 
+        if (newMessage.Content == oldContent)
+        {
+            _logger.Log($"Skipping LogChannel post for MessageUpdated event because the message's .Content did not change. " +
+                $"This means some other property was edited, e.g. Discord auto-unfurled a link, or the message was pinned.");
+            return;
+        }
+
         var author = newMessage.Author;
         if (author.Id == client.CurrentUser.Id) return; // Don't process self.
         if (author.IsBot) return; // Don't listen to bots

--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -42,7 +42,7 @@ public class FilterService
     public void RegisterEvents(IIzzyClient client)
     {
         client.MessageReceived += async (message) => await DiscordHelper.LeakOrAwaitTask(ProcessMessage(message, client));
-        client.MessageUpdated += async (_oldMessage, newMessage, channel) => await DiscordHelper.LeakOrAwaitTask(ProcessMessageUpdate(newMessage, channel, client));
+        client.MessageUpdated += async (oldContent, newMessage, channel) => await DiscordHelper.LeakOrAwaitTask(ProcessMessageUpdate(oldContent, newMessage, channel, client));
     }
 
     private async Task LogFilterTrip(IIzzyContext context, string word, string category,
@@ -153,9 +153,12 @@ public class FilterService
         }
     }
 
-    public async Task ProcessMessageUpdate(IIzzyMessage newMessage,
+    public async Task ProcessMessageUpdate(
+        string? oldContent, IIzzyMessage newMessage,
         IIzzyMessageChannel channel, IIzzyClient client)
     {
+        if (newMessage.Content == oldContent) return; // Ignore non-content edits
+
         if (newMessage.Author.Id == client.CurrentUser.Id) return; // Don't process self.
         
         if (!_config.FilterEnabled) return;


### PR DESCRIPTION
After #309 was released, the only issue we've noticed in Manechat is that Izzy often logs "non-edits" where the before and after `.Content` are identical. In retrospect it's obvious that MessageUpdated covers updates to all message properties, but `.Content` is usually the only one we care about, so we just need to check if `.Content` changed.

Then I fixed #182 since I remembered that issue exists and has essentially the same fix.