### PR TITLE
fix parsing multi-digit days such as '14 may'

### DIFF
--- a/Izzy-Moonbot/Helpers/TimeHelper.cs
+++ b/Izzy-Moonbot/Helpers/TimeHelper.cs
@@ -409,8 +409,11 @@ public static class TimeHelper
     {
         int dateInt;
         bool isInt = int.TryParse(dateToken, out dateInt);
+
         // support "st"/"nd"/"rd"/"th" suffixes without advertising them
-        bool isIntWithSuffix = dateToken.Length >= 2 && int.TryParse(dateToken.Substring(0, dateToken.Length - 2), out dateInt);
+        bool isIntWithSuffix = false;
+        if (!isInt)
+            isIntWithSuffix = dateToken.Length >= 2 && int.TryParse(dateToken.Substring(0, dateToken.Length - 2), out dateInt);
 
         if (!isInt && !isIntWithSuffix) {
             errorString = $"\"{dateToken}\" is not a positive integer";

--- a/Izzy-MoonbotTests/Service/TimeHelperTests.cs
+++ b/Izzy-MoonbotTests/Service/TimeHelperTests.cs
@@ -276,6 +276,19 @@ public class TimeHelperTests
             new DateTimeOffset(2020, 1, 1, 12, 0, 0, 0, TimeSpan.Zero), ScheduledJobRepeatType.None, ""
         );
         Assert.AreEqual(err, null);
+
+        // regression test that two-digit days also work
+        AssertTryParseDateTime(
+            TimeHelper.TryParseDateTime("on 15 jan 2020 12:00 UTC+0", out err),
+            new DateTimeOffset(2020, 1, 15, 12, 0, 0, 0, TimeSpan.Zero), ScheduledJobRepeatType.None, ""
+        );
+        Assert.AreEqual(err, null);
+
+        AssertTryParseDateTime(
+            TimeHelper.TryParseDateTime("on 15th jan 2020 12:00 UTC+0", out err),
+            new DateTimeOffset(2020, 1, 15, 12, 0, 0, 0, TimeSpan.Zero), ScheduledJobRepeatType.None, ""
+        );
+        Assert.AreEqual(err, null);
     }
 
     [TestMethod()]


### PR DESCRIPTION
Apparently [the `out` param of `int.TryParse()` gets set to `0` by a failed conversion](https://learn.microsoft.com/en-us/dotnet/api/system.int32.tryparse?view=net-7.0), so the existing code was successfully converting "14" to 14 and then trying to support suffixes by converting "14".substr(2) -> "" to an int, which of course fails, but that also overwrites the 14 with 0.

![image](https://user-images.githubusercontent.com/5285357/214892222-ae966d36-e48f-48c5-8390-ecd4d8478f97.png)
