### PR TITLE
reject 'possible commands' that don't have a letter immediately following the command prefix

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -396,8 +396,15 @@ namespace Izzy_Moonbot
                     return;
                 }
 
-                string parsedMessage = message.Content[1..].TrimStart();
-                    
+                string parsedMessage = message.Content[1..];
+                if (!char.IsLetter(parsedMessage[0]))
+                {
+                    _logger.Log(LogLevel.Information, $"Ignoring message {messageParam.CleanContent} because the {_config.Prefix} " +
+                        $"is not followed immediately by a letter.");
+                    return;
+                }
+
+
                 if (_config.Aliases.Count != 0)
                 {
                     var command = parsedMessage.Split(" ");


### PR DESCRIPTION
Not a big deal, but so easy to fix we might as well.

![image](https://user-images.githubusercontent.com/5285357/234936737-4a8eb9fa-ce4d-4298-a50c-25e5c81ed2ae.png)

![image](https://user-images.githubusercontent.com/5285357/234936523-95dd6a51-186d-44dc-aaaf-e83a425b2c2c.png)

Testing after this change:

```sh
[2023-04-27 17:59:43 INF] Received possible command: .
just
[2023-04-27 17:59:43 INF] Ignoring message .
just because the . is not followed immediately by a letter.
...
[2023-04-27 17:59:57 INF] Received possible command: ...test
[2023-04-27 17:59:57 INF] Ignoring message ...test because the . is not followed immediately by a letter.
```