### PR TITLE
stop logging a spam pressure breakdown on every single message in the server

### DIFF
--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -258,8 +258,8 @@ public class SpamService
 
         var newPressure = await IncreasePressure(id, pressure);
 
-        // This is by far the most common log line under normal circumstances, but also a fairly verbose one, so it's worth being extra concise and having lots of line breaks
-        _logger.Log($"\nPressure channge: {oldPressureAfterDecay} + {pressure} = {newPressure} out of {_config.SpamMaxPressure}\n{string.Join('\n', pressureBreakdown)}", context, level: LogLevel.Debug);
+        // Logging on every single server message proved too spammy, but this is indispensable for testing spam changes, so leaving as a comment for us to uncomment during manual testing.
+        // _logger.Log($"\nPressure channge: {oldPressureAfterDecay} + {pressure} = {newPressure} out of {_config.SpamMaxPressure}\n{string.Join('\n', pressureBreakdown)}", context, level: LogLevel.Debug);
 
         // If this user already tripped spam pressure, but was either immune to silencing or managed to
         // send another message before Izzy could respond, we don't want duplicate notifications


### PR DESCRIPTION
In theory this is a perfect use case for Trace or Debug log levels, but sadly in practice `journalctl`'s support for log levels doesn't work at all (despite the docs and internet claims that `-p info` would show everything at info or above).

Separately, AFAIK we've never actually debugged any production issues using these logs. They're sometimes useful during spam development, hence leaving this around as a comment, but at this point I'm convinced this is just a bad use of log file space to leave in the production code.