### PR TITLE
print latency update logs only in debug builds

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -112,8 +112,10 @@ namespace Izzy_Moonbot
 
                 _client.LatencyUpdated += async (int old, int value) =>
                 {
+                    #if DEBUG
                     _logger.Log(LogLevel.Debug, $"Latency = {value}ms.");
-                    
+                    #endif
+
                     if (_config.DiscordActivityName != null)
                     {
                         if (_client.Activity.Name != _config.DiscordActivityName ||


### PR DESCRIPTION
another spammy log that's not helpful to print constantly in production