### PR TITLE
don't crash on a message that's just '.'

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -399,7 +399,7 @@ namespace Izzy_Moonbot
                 }
 
                 string parsedMessage = message.Content[1..];
-                if (!char.IsLetter(parsedMessage[0]))
+                if (parsedMessage.Length == 0 || !char.IsLetter(parsedMessage[0]))
                 {
                     _logger.Log(LogLevel.Information, $"Ignoring message {messageParam.CleanContent} because the {_config.Prefix} " +
                         $"is not followed immediately by a letter.");


### PR DESCRIPTION
caught this while testing unrelated stuff

![image](https://user-images.githubusercontent.com/5285357/235365868-9ccc2860-6191-4a3b-af22-6eb7ef3678f5.png)
