### PR TITLE
Compose Update 2.17.0 Compliance

### DIFF
--- a/Izzy-Moonbot/Docker Compose/docker-compose.yml
+++ b/Izzy-Moonbot/Docker Compose/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '3.9'
-name: IzzyMoonbot
+name: izzymoonbot
 services:
     izzy:
         image: ghcr.io/manechat/izzy-moonbot:latest


### PR DESCRIPTION
Update compose project name value to be compliant with the new validation rules in Compose 2.17.0: https://docs.docker.com/compose/release-notes/#2170