### PR TITLE
Deactivate Redundant Action Triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "mane" ]
+  #push:
+  #  branches: [ "mane" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "mane" ]

--- a/.github/workflows/dotnet-nobuild.yml
+++ b/.github/workflows/dotnet-nobuild.yml
@@ -1,8 +1,8 @@
 name: .NET Tests
 
 on:
-  push:
-    branches: [ "mane" ]
+  #push:
+  #  branches: [ "mane" ]
   pull_request:
     branches: [ "mane" ]
     # Inverse of the ignore paths in dotnet.yml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,8 +4,8 @@
 name: .NET Tests
 
 on:
-  push:
-    branches: [ "mane" ]
+  #push:
+  #  branches: [ "mane" ]
   pull_request:
     branches: [ "mane" ]
     # Don't run checks on things non-code related. Add additional ignores below.


### PR DESCRIPTION
As all pushes to `mane` branch must now go through a PR, the push events for the `mane` branch can be deactivated as they are redundant and result in unnecessary check runs.