### PR TITLE
filter simplification part 2: replace FilteredWords dict<str, set<str>> with a simpler FilterWords set<str>, including auto-migrating the .conf file

### DIFF
--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -120,6 +120,12 @@ public class ConfigDescriber
                 "Whether I will not take action against my developers when I detect a slur. " +
                 "Please note that I __will still check for filter violations for developers__. I just won't try to delete the message or silence the user.",
                 ConfigItemCategory.Filter));
+        _config.Add("FilterWords",
+            new ConfigItem(ConfigItemType.StringSet,
+                "The list of words I filter. If FilterEnabled is true, then anytime I see a message with one of these words, I'll delete the message, silence the user, and post a notification in ModChannel.\n" +
+                "See FilterIgnoredChannels, FilterBypassRoles and FilterDevBypass for exceptions.\n" +
+                "If you want a filter that doesn't silence the user, see Discord's AutoMod.",
+                ConfigItemCategory.Filter));
         _config.Add("FilteredWords",
             new ConfigItem(ConfigItemType.StringSetDictionary,
                 "The map of filter category names to a list of words in that category.\n" +

--- a/Izzy-Moonbot/Helpers/FileHelper.cs
+++ b/Izzy-Moonbot/Helpers/FileHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Discord.Commands;
 using Izzy_Moonbot.Settings;
@@ -76,6 +77,13 @@ public static class FileHelper
             settings = JsonConvert.DeserializeObject<Config>(fileContents);
             if (settings == null)
                 throw new InvalidDataException($"Failed to deserialize settings at {filepath}");
+            if (settings.FilteredWords.Any() && !settings.FilterWords.Any())
+            {
+                foreach (var (category, words) in settings.FilteredWords)
+                    settings.FilterWords.UnionWith(words);
+                settings.FilteredWords.Clear();
+                await SaveConfigAsync(settings);
+            }
         }
 
         return settings;

--- a/Izzy-Moonbot/Modules/DevModule.cs
+++ b/Izzy-Moonbot/Modules/DevModule.cs
@@ -158,36 +158,6 @@ public class DevModule : ModuleBase<SocketCommandContext>
                     $"\n```Your faithful Bot,\nIzzy Moonbot");
 
                 break;
-            case "import-filter":
-                {
-                    var toFilter = Context.Message.ReferencedMessage.CleanContent.Split('\n').AsEnumerable();
-                    if (args[1] == "no") toFilter = toFilter.Skip(1);
-                    else toFilter = toFilter.Skip(2);
-
-                    var msg = await ReplyAsync(
-                        $"Confirm: Import the list of words you replied to into the `{args[0]}` list? Checking reactions in 10 seconds.");
-                    await msg.AddReactionAsync(Emoji.Parse("✅"));
-                    var _ = Task.Factory.StartNew(async () =>
-                    {
-                        await Task.Delay(Convert.ToInt32(10000));
-                        var users = msg.GetReactionUsersAsync(Emoji.Parse("✅"), 2);
-                        if (users.AnyAsync(users =>
-                        {
-                            return users.Any(user => user.Id == Context.User.Id) ? true : false;
-                        }).Result)
-                        {
-                            await msg.RemoveAllReactionsAsync();
-                            await msg.ModifyAsync(message => message.Content = "⚠  **Importing. Please wait...**");
-
-                            _config.FilteredWords[args[1]].UnionWith(toFilter);
-
-                            await FileHelper.SaveConfigAsync(_config);
-                            await msg.ModifyAsync(message => message.Content = "⚠  **Done!**");
-                        }
-                    });
-
-                    break;
-                }
             case "raid":
                 {
                     // Simulates a raid.

--- a/Izzy-Moonbot/Settings/Config.cs
+++ b/Izzy-Moonbot/Settings/Config.cs
@@ -45,6 +45,7 @@ public class Config
         FilterIgnoredChannels = new HashSet<ulong>();
         FilterBypassRoles = new HashSet<ulong>();
         FilterDevBypass = true;
+        FilterWords = new HashSet<string>();
         FilteredWords = new Dictionary<string, HashSet<string>>();
 
         // Pressure settings
@@ -129,6 +130,7 @@ public class Config
     public HashSet<ulong> FilterIgnoredChannels { get; set; }
     public HashSet<ulong> FilterBypassRoles { get; set; }
     public bool FilterDevBypass { get; set; }
+    public HashSet<string> FilterWords { get; set; }
     public Dictionary<string, HashSet<string>> FilteredWords { get; set; }
 
     // Pressure settings

--- a/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
@@ -632,6 +632,13 @@ public class ConfigCommandTests
         Assert.AreEqual(cfg.FilterDevBypass, false);
         Assert.AreEqual("I've set `FilterDevBypass` to the following content: False", generalChannel.Messages.Last().Content);
 
+        // post ".config FilterWords add mudpony"
+        TestUtils.AssertSetsAreEqual(new HashSet<string>(), cfg.FilterWords);
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config FilterWords add mudpony");
+        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "FilterWords", "add mudpony");
+        TestUtils.AssertSetsAreEqual(new HashSet<string> { "mudpony" }, cfg.FilterWords);
+        Assert.AreEqual("I added the following content to the `FilterWords` string list:\n```\nmudpony\n```", generalChannel.Messages.Last().Content);
+
         // post ".config FilteredWords add slurs mudpony"
         TestUtils.AssertDictsOfSetsAreEqual(new Dictionary<string, HashSet<string>>(), cfg.FilteredWords);
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config FilteredWords add slurs mudpony");
@@ -808,7 +815,7 @@ public class ConfigCommandTests
         // Ensure we can't forget to keep this test up to date
         var configPropsCount = typeof(Config).GetProperties().Length;
 
-        Assert.AreEqual(49, configPropsCount,
+        Assert.AreEqual(50, configPropsCount,
             $"\nIf you just added or removed a config item, then this test is probably out of date");
 
         Assert.AreEqual(configPropsCount * 2, generalChannel.Messages.Count(),

--- a/Izzy-MoonbotTests/Tests/FilterServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/FilterServiceTests.cs
@@ -34,7 +34,7 @@ public class FilterServiceTests
     {
         var (cfg, _, (_, sunny), _, (generalChannel, modChat, _), guild, client) = TestUtils.DefaultStubs();
         cfg.ModChannel = modChat.Id;
-        cfg.FilteredWords.Add("jinxies", new HashSet<string> { "magic", "wing", "feather", "mayonnaise" });
+        cfg.FilterWords = new HashSet<string> { "magic", "wing", "feather", "mayonnaise" };
         SetupFilterService(cfg, guild, client, sunny);
 
         await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "this is a completely ordinary chat message");
@@ -53,7 +53,6 @@ public class FilterServiceTests
         TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
         {
             ("User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
-            ("Category", "jinxies"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Trigger Word", "magic"),
             ("Filtered Message", "magic wings of mayonnaise"),
@@ -68,7 +67,7 @@ public class FilterServiceTests
     {
         var (cfg, _, (_, sunny), _, (generalChannel, modChat, _), guild, client) = TestUtils.DefaultStubs();
         cfg.ModChannel = modChat.Id;
-        cfg.FilteredWords.Add("jinxies", new HashSet<string> { "magic", "wing", "feather", "mayonnaise" });
+        cfg.FilterWords = new HashSet<string> { "magic", "wing", "feather", "mayonnaise" };
         SetupFilterService(cfg, guild, client, sunny);
 
         Assert.AreEqual(0, modChat.Messages.Count);


### PR DESCRIPTION
The meat of #323

Most of this is cleaning out the concept of filter "categories" now that those don't exist any more. Aside from straightforward code updates, `.test import-filter` had to finally get deleted, and the filter test string is now a single string instead of something we insert the category into.