### PR TITLE
simplify raid logic by defining a "raid" as just a number of recent joins

### DIFF
--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -185,7 +185,7 @@ public class ConfigDescriber
         // Raid settings
         _config.Add("RaidProtectionEnabled",
             new ConfigItem(ConfigItemType.Boolean,
-                "Whether or not I will protect this server against raids. Consider disabling this if you anticipate a large increase in member count over a few days (3000 in 4 days for example)",
+                "Whether or not I will protect this server against raids. Consider disabling this if you anticipate a large increase in member count over a few days (e.g. 3000 in 4 days)",
                 ConfigItemCategory.Raid));
         _config.Add("AutoSilenceNewJoins",
             new ConfigItem(ConfigItemType.Boolean,
@@ -194,31 +194,23 @@ public class ConfigDescriber
                 ConfigItemCategory.Raid));
         _config.Add("SmallRaidSize",
             new ConfigItem(ConfigItemType.Integer,
-                "How many users have to join in `SmallRaidTime` seconds in order for me to notify mods about a potential raid.",
-                ConfigItemCategory.Raid));
-        _config.Add("SmallRaidTime",
-            new ConfigItem(ConfigItemType.Double,
-                "In how many seconds do `SmallRaidSize` users need to join in order for me to notify mods about a potential raid.",
+                "How many recent joins (see `RecentJoinDecay`) it takes for me to notify mods about a potential raid.",
                 ConfigItemCategory.Raid));
         _config.Add("LargeRaidSize",
             new ConfigItem(ConfigItemType.Integer,
-                "How many users have to join in `LargeRaidTime` seconds in order for me to automatically enable raidsilence.",
-                ConfigItemCategory.Raid));
-        _config.Add("LargeRaidTime",
-            new ConfigItem(ConfigItemType.Double,
-                "In how many seconds do `LargeRaidSize` users need to join in order for me to automatically enable raidsilence.",
+                "How many recent joins (see `RecentJoinDecay`) it takes for me to automatically enable `AutoSilenceNewUsers`.",
                 ConfigItemCategory.Raid));
         _config.Add("RecentJoinDecay",
             new ConfigItem(ConfigItemType.Double,
-                "How long to wait, in seconds, before I no longer considering a new member a 'recent join' (no longer considered part of any raid if one were to occur).",
+                "How long to wait, in seconds, before I no longer consider a new member a 'recent join'.",
                 ConfigItemCategory.Raid));
         _config.Add("SmallRaidDecay",
             new ConfigItem(ConfigItemType.Double,
-                "How many minutes do I wait before automatically downgrading a Small raid to No raid.",
+                "How many minutes do I wait before declaring a small raid over.",
                 ConfigItemCategory.Raid, true));
         _config.Add("LargeRaidDecay",
             new ConfigItem(ConfigItemType.Double,
-                "How many minutes do I wait before automatically downgrading a Large raid to a Small raid.",
+                "How many minutes do I wait before declaring a large raid over (and automatically disabling `AutoSilenceNewUsers`).",
                 ConfigItemCategory.Raid, true));
     }
 

--- a/Izzy-Moonbot/Modules/RaidModule.cs
+++ b/Izzy-Moonbot/Modules/RaidModule.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord.Commands;
-using Izzy_Moonbot.Adapters;
 using Izzy_Moonbot.Attributes;
 using Izzy_Moonbot.Helpers;
 using Izzy_Moonbot.Service;
 using Izzy_Moonbot.Settings;
-using Serilog;
 
 namespace Izzy_Moonbot.Modules;
 
@@ -61,7 +58,7 @@ public class RaidModule : ModuleBase<SocketCommandContext>
 
         var msg = $"I've set `AutoSilenceNewJoins` to `true`";
         if (recentJoins.Any())
-            msg += $" and silenced the following recent joins: {string.Join(' ', recentJoins.Select(u => $"<@{u.Id}>"))}";
+            msg += $" and silenced the following recent joins: {string.Join(' ', recentJoins.Select(u => $"<@{u.Id}>"))}\n" + RaidService.PLEASE_ASSOFF;
         else
             // "users must have users in them" is a poorly chosen error message that this
             // command once produced, and was so funny we felt the need to keep it around.
@@ -83,7 +80,8 @@ public class RaidModule : ModuleBase<SocketCommandContext>
         _generalStorage.ManualRaidSilence = false;
         await FileHelper.SaveGeneralStorageAsync(_generalStorage);
 
-        await ReplyAsync($"Jinxie avoided! I've set `AutoSilenceNewJoins` back to `false`");
+        await ReplyAsync($"Jinxie avoided! I've set `AutoSilenceNewJoins` back to `false`, " +
+            "and consider the raid to be over. " + RaidService.ALARMS_ACTIVE);
     }
 
     [Command("getrecentjoins")]

--- a/Izzy-Moonbot/Service/RaidService.cs
+++ b/Izzy-Moonbot/Service/RaidService.cs
@@ -112,7 +112,8 @@ public class RaidService
                 // Either someone ran .assoff or this escalated to a large raid. Either way, we don't need a "small raid is over" message.
                 if (_generalStorage.CurrentRaidMode != RaidMode.Small) return;
 
-                if (_state.RecentJoins.Count >= _config.SmallRaidSize)
+                var recentJoinCount = GetRecentJoins(guild).Count;
+                if (recentJoinCount >= _config.SmallRaidSize)
                 {
                     _log.Log("Small raid is ongoing, inform mods it will have to be ended manually");
 
@@ -170,7 +171,8 @@ public class RaidService
 
                 // Rather than "decay" separately from large to small and then to none, it's simpler to just say
                 // a large raid doesn't end until we've fallen below the threshhold for any size of raid.
-                if (_state.RecentJoins.Count >= _config.SmallRaidSize)
+                var recentJoinCount = GetRecentJoins(guild).Count;
+                if (recentJoinCount >= _config.SmallRaidSize)
                 {
                     _log.Log("Large raid is ongoing, inform mods it will have to be ended manually");
 

--- a/Izzy-Moonbot/Service/RaidService.cs
+++ b/Izzy-Moonbot/Service/RaidService.cs
@@ -120,6 +120,11 @@ public class RaidService
                     var msg = TIME_SINCE_SMALL() + ", " + BUT_RECENT() + CONSIDER_ONGOING + "\n\n" + PLEASE_ASSOFF;
                     await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
                 }
+                else if (_generalStorage.ManualRaidSilence)
+                {
+                    var msg = TIME_SINCE_SMALL() + ", but `.ass` was run in the meantime" + CONSIDER_ONGOING + "\n\n" + PLEASE_ASSOFF;
+                    await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+                }
                 else
                 {
                     _log.Log("Ending small raid");

--- a/Izzy-Moonbot/Service/RaidService.cs
+++ b/Izzy-Moonbot/Service/RaidService.cs
@@ -1,19 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Discord.Commands;
 using Discord.WebSocket;
 using Izzy_Moonbot.Helpers;
 using Izzy_Moonbot.Settings;
-using Microsoft.Extensions.Logging;
 
 namespace Izzy_Moonbot.Service;
 
-/*
- * The service responsible for handling antiraid functions
- * TODO: better description lol
- */
 public class RaidService
 {
     private readonly LoggingService _log;
@@ -37,11 +30,6 @@ public class RaidService
     public void RegisterEvents(DiscordSocketClient client)
     {
         client.UserJoined += (member) => Task.Run(async () => { await ProcessMemberJoin(member); });
-    }
-
-    public bool UserRecentlyJoined(ulong id)
-    {
-        return _state.RecentJoins.Contains(id);
     }
 
     // This method proactively checks that the joins still are recent and updates _state if any expired,
@@ -72,222 +60,161 @@ public class RaidService
         return recentGuildUsers;
     }
 
-    private async Task DecaySmallRaid(SocketGuild guild)
+    public string TIME_SINCE_SMALL() => $"{_config.SmallRaidDecay} minutes have passed since I detected a spike of {_config.SmallRaidSize} recent joins";
+    public string TIME_SINCE_LARGE() => $"{_config.LargeRaidDecay} minutes have passed since I detected a spike of {_config.LargeRaidSize} recent joins";
+    public string BUT_RECENT() => $"but there are {_state.RecentJoins.Count} (>={_config.SmallRaidSize}) recent joins now";
+    public string AND_ONLY_RECENT() => $"and there are only {_state.RecentJoins.Count} (<{_config.SmallRaidSize}) recent joins now";
+    public static string CONSIDER_OVER = ", so I consider the raid to be over.";
+    public static string CONSIDER_ONGOING = ", so I consider the raid to be ongoing and will not generate any additional messages.";
+    public static string ALARMS_ACTIVE = "Any future spike in recent joins will generate a new alarm.";
+    public static string PLEASE_ASSOFF = "Please run `.assoff` when you believe the raid is over, so I know to start alarming on join spikes again.";
+
+    private string RaidersDescription(List<SocketGuildUser> recentJoins)
     {
-        _generalStorage.CurrentRaidMode = RaidMode.None;
-
-        _config.AutoSilenceNewJoins = false;
-        
-        await FileHelper.SaveConfigAsync(_config);
-
-        await _modLog.CreateModLog(guild)
-            .SetContent(
-                $"The raid has ended. I've disabled raid defences and cleared my internal cache of all recent joins.")
-            .SetFileLogContent("The raid has ended. I've disabled raid defences and cleared my internal cache of all recent joins.")
-            .Send();
-
-        await FileHelper.SaveGeneralStorageAsync(_generalStorage);
+        var raiderDescriptions = new List<string>();
+        recentJoins.ForEach(member =>
+        {
+            var joinDate = "`Couldn't get member join time`";
+            if (member.JoinedAt.HasValue) joinDate = $"<t:{member.JoinedAt.Value.ToUnixTimeSeconds()}:F>";
+            raiderDescriptions.Add($"<@{member.Id}> {member.Username}#{member.Discriminator} (joined: {joinDate})");
+        });
+        return string.Join($"\n", raiderDescriptions);
     }
 
-    private async Task DecayLargeRaid(SocketGuild guild)
+    private async Task TripSmallRaid(SocketGuild guild, List<SocketGuildUser> recentJoins)
     {
+        _log.Log("Small raid detected!");
+
+        var msg = $"<@&{_config.ModRole}> Bing-bong! Possible raid detected! ({_config.SmallRaidSize} (`SmallRaidSize`) recent joins)\n\n" +
+            $"{RaidersDescription(recentJoins)}";
+        await _modLog.CreateModLog(guild)
+            .SetContent(msg +
+                $"\n\nPossible commands for this scenario are:\n" +
+                $"`{_config.Prefix}ass` - Set `AutoSilenceNewJoins` to `true` and silence recent joins (as defined by `.config RecentJoinDecay`).\n" +
+                $"`{_config.Prefix}assoff` - Set `AutoSilenceNewJoins` to `false`.\n" +
+                $"`{_config.Prefix}stowaways` - List non-bot, non-mod users who do not have the member role.\n" +
+                $"`{_config.Prefix}getrecentjoins` - Get a list of recent joins (as defined by `.config RecentJoinDecay`).\n" +
+                $"\n" +
+                $"If you do not believe this is a raid, simply do nothing. If you do believe this is a raid, typically you should run `.ass`, then manually vet every user who joins " +
+                    $"(ending in a kick, ban, or manually adding the MemberRole) until you believe the raid is over, then run `.assoff`, and finally `.stowaways` to double-check if we missed anyone.")
+            .SetFileLogContent(msg)
+            .Send();
+
         _generalStorage.CurrentRaidMode = RaidMode.Small;
-
-        if (!_generalStorage.ManualRaidSilence) _config.AutoSilenceNewJoins = false;
-
-        var manualRaidActive =
-            " `.ass` was run manually, so I'm not automatically disabling `AutoSilenceNewJoins`. Run `.assoff` to manually end the raid.";
-        if (!_generalStorage.ManualRaidSilence) manualRaidActive = "";
-        await _modLog.CreateModLog(guild)
-            .SetContent($"The raid has deescalated. I'm lowering the raid level down to Small.{manualRaidActive}")
-            .SetFileLogContent($"The raid has deescalated. I'm lowering the raid level down to Small.{manualRaidActive}")
-            .Send();
-
-        await FileHelper.SaveConfigAsync(_config);
         await FileHelper.SaveGeneralStorageAsync(_generalStorage);
-    }
 
-    public async Task CheckForTrip(SocketGuild guild)
-    {
-        var recentJoins = GetRecentJoins(guild);
-
-        if (_state.CurrentSmallJoinCount >= _config.SmallRaidSize && _generalStorage.CurrentRaidMode == RaidMode.None)
-        {
-            var potentialRaiders = new List<string>();
-
-            _log.Log(
-                "Small raid detected!");
-
-            recentJoins.ForEach(member =>
+        if (_config.SmallRaidDecay != null)
+            _ = Task.Run(async () =>
             {
-                var joinDate = "`Couldn't get member join time`";
-                if (member.JoinedAt.HasValue) joinDate = $"<t:{member.JoinedAt.Value.ToUnixTimeSeconds()}:F>";
-                potentialRaiders.Add($"{member.Username}#{member.Discriminator} (joined: {joinDate})");
-            });
+                await Task.Delay(Convert.ToInt32(_config.SmallRaidDecay * 60 * 1000));
+                if (_config.SmallRaidDecay == null) return; // Was disabled
 
-            // Potential raid. Bug the mods
-            await _modLog.CreateModLog(guild)
-                .SetContent(
-                    $"<@&{_config.ModRole}> Bing-bong! Possible raid detected! ({_config.SmallRaidSize} (`SmallRaidSize`) users joined within {_config.SmallRaidTime} (`SmallRaidTime`) seconds.)\n\n" +
-                    $"{string.Join($"\n", potentialRaiders)}\n\n" +
-                    $"Possible commands for this scenario are:\n" +
-                    $"`{_config.Prefix}ass` - Set `AutoSilenceNewJoins` to `true` and silence recent joins (as defined by `.config RecentJoinDecay`).\n" +
-                    $"`{_config.Prefix}assoff` - Set `AutoSilenceNewJoins` to `false`.\n" +
-                    $"`{_config.Prefix}stowaways` - List non-bot, non-mod users who do not have the member role.\n" +
-                    $"`{_config.Prefix}getrecentjoins` - Get a list of recent joins (as defined by `.config RecentJoinDecay`).\n" +
-                    $"\n" +
-                    $"If you do not believe this is a raid, simply do nothing. If you do believe this is a raid, typically you should run `.ass`, then manually vet every user who joins " +
-                        $"(ending in a kick, ban, or manually adding the MemberRole) until you believe the raid is over, then run `.assoff`, and finally `.stowaways` to double-check if we missed anyone.")
-                .SetFileLogContent($"Bing-bong! Possible raid detected! ({_config.SmallRaidSize} (`SmallRaidSize`) users joined within {_config.SmallRaidTime} (`SmallRaidTime`) seconds.)\n" +
-                                   $"{string.Join($"\n", potentialRaiders)}\n")
-                .Send();
+                // Either someone ran .assoff or this escalated to a large raid. Either way, we don't need a "small raid is over" message.
+                if (_generalStorage.CurrentRaidMode != RaidMode.Small) return;
 
-            _generalStorage.CurrentRaidMode = RaidMode.Small;
-            await FileHelper.SaveGeneralStorageAsync(_generalStorage);
-        }
-
-        if (_state.CurrentLargeJoinCount >= _config.LargeRaidSize && _generalStorage.CurrentRaidMode != RaidMode.Large)
-        {
-            var potentialRaiders = new List<string>();
-
-            _log.Log(
-                "Large raid detected!");
-
-            await _modService.SilenceUsers(recentJoins, "auto-silenced all suspected raiders after a large raid was detected");
-
-            recentJoins.ForEach(async member =>
-            {
-                var joinDate = "`Couldn't get member join time`";
-                if (member.JoinedAt.HasValue) joinDate = $"<t:{member.JoinedAt.Value.ToUnixTimeSeconds()}:F>";
-                potentialRaiders.Add($"{member.Username}#{member.Discriminator} (joined: {joinDate})");
-
-                if (member.Roles.Any(role => role.Id == _config.MemberRole))
+                if (_state.RecentJoins.Count >= _config.SmallRaidSize)
                 {
-                    await _modService.SilenceUser(member, "auto-silenced all suspected raiders after a large raid was detected");
+                    _log.Log("Small raid is ongoing, inform mods it will have to be ended manually");
+
+                    var msg = TIME_SINCE_SMALL() + ", " + BUT_RECENT() + CONSIDER_ONGOING + "\n\n" + PLEASE_ASSOFF;
+                    await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+                }
+                else
+                {
+                    _log.Log("Ending small raid");
+
+                    _generalStorage.CurrentRaidMode = RaidMode.None;
+                    await FileHelper.SaveGeneralStorageAsync(_generalStorage);
+
+                    var msg = TIME_SINCE_SMALL() + ", " + AND_ONLY_RECENT() + CONSIDER_OVER + " " + ALARMS_ACTIVE;
+                    await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
                 }
             });
+    }
 
-            if (_generalStorage.CurrentRaidMode == RaidMode.None)
-            {
-                await _modLog.CreateModLog(guild)
-                    .SetContent(
-                        $"<@&{_config.ModRole}> Bing-bong! Raid detected! ({_config.LargeRaidSize} (`LargeRaidSize`) users joined within {_config.LargeRaidTime} (`LargeRaidTime`) seconds.)\n" +
-                        $"I have automatically silenced all the members below and enabled autosilencing users on join.\n\n" +
-                        $"{string.Join($"\n", potentialRaiders)}\n\n" +
-                        $"Possible commands for this scenario are:\n" +
-                        $"`{_config.Prefix}assoff` - Set `AutoSilenceNewJoins` to `false`.\n" +
-                        $"`{_config.Prefix}stowaways` - List non-bot, non-mod users who do not have the member role.\n" +
-                        $"`{_config.Prefix}getrecentjoins` - Get a list of recent joins (as defined by `.config RecentJoinDecay`).")
-                    .SetFileLogContent($"Bing-bong! Raid detected! ({_config.LargeRaidSize} (`LargeRaidSize`) users joined within {_config.LargeRaidTime} (`LargeRaidTime`) seconds.)\n" +
-                                       $"I have automatically silenced all the members below members and enabled autosilencing users on join.\n" +
-                                       $"{string.Join($"\n", potentialRaiders)}\n")
-                    .Send();
-            }
-            else
-            {
-                if (_config.AutoSilenceNewJoins)
-                    await _modLog.CreateModLog(guild)
-                        .SetContent(
-                            $"<@&{_config.ModRole}> **The current raid has escalated. Silencing new joins has already been enabled manually.** ({_config.LargeRaidSize} (`LargeRaidSize`) users joined within {_config.LargeRaidTime} (`LargeRaidTime`) seconds.)")
-                        .SetFileLogContent($"The current raid has escalated. Silencing new joins has already been enabled manually. ({_config.LargeRaidSize} (`LargeRaidSize`) users joined within {_config.LargeRaidTime} (`LargeRaidTime`) seconds.)")
-                        .Send();
-                else
-                    await _modLog.CreateModLog(guild)
-                        .SetContent(
-                            $"<@&{_config.ModRole}> **The current raid has escalated and I have automatically enabled silencing new joins and I've silenced those considered part of the raid.** ({_config.LargeRaidSize} (`LargeRaidSize`) users joined within {_config.LargeRaidTime} (`LargeRaidTime`) seconds.)")
-                        .SetFileLogContent($"The current raid has escalated and I have automatically enabled silencing new joins and I've silenced those considered part of the raid. ({_config.LargeRaidSize} (`LargeRaidSize`) users joined within {_config.LargeRaidTime} (`LargeRaidTime`) seconds.)")
-                        .Send();
-            }
+    private async Task TripLargeRaid(SocketGuild guild, List<SocketGuildUser> recentJoins)
+    {
+        _log.Log("Large raid detected!");
 
-            _generalStorage.CurrentRaidMode = RaidMode.Large;
+        _generalStorage.CurrentRaidMode = RaidMode.Large;
+        await FileHelper.SaveGeneralStorageAsync(_generalStorage);
+
+        var autoSilenceValueBefore = _config.AutoSilenceNewJoins;
+        if (!autoSilenceValueBefore)
+        {
             _config.AutoSilenceNewJoins = true;
-
             await FileHelper.SaveConfigAsync(_config);
-            await FileHelper.SaveGeneralStorageAsync(_generalStorage);
+
+            await _modService.SilenceUsers(recentJoins, "auto-silenced all suspected raiders after a large raid was detected");
         }
+
+        var msg = $"<@&{_config.ModRole}> Bing-bong! Raid detected! ({_config.LargeRaidSize} (`LargeRaidSize`) recent joins)";
+        msg += autoSilenceValueBefore
+            ? "`AutoSilenceNewJoins` was already `true`, so I've taken no action.\n\n"
+            : "I've set `AutoSilenceNewJoins` to `true` and silenced the following recent joins:\n\n";
+        msg += $"{RaidersDescription(recentJoins)}\n\n";
+        msg += autoSilenceValueBefore
+            ? PLEASE_ASSOFF
+            : $"After {_config.LargeRaidDecay} minutes, if this raid appears to be over, I will automatically reset `AutoSilenceNewJoins` back to `false` (unless you run `.ass` before then).";
+
+        await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+
+        if (_config.LargeRaidDecay != null)
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(Convert.ToInt32(_config.LargeRaidDecay * 60 * 1000));
+                if (_config.SmallRaidDecay == null) return; // Was disabled
+
+                // Someone must have run.assoff already, so we don't need a "large raid is over" message.
+                if (_generalStorage.CurrentRaidMode != RaidMode.Large) return;
+
+                // Rather than "decay" separately from large to small and then to none, it's simpler to just say
+                // a large raid doesn't end until we've fallen below the threshhold for any size of raid.
+                if (_state.RecentJoins.Count >= _config.SmallRaidSize)
+                {
+                    _log.Log("Large raid is ongoing, inform mods it will have to be ended manually");
+
+                    var msg = TIME_SINCE_LARGE() + ", " + BUT_RECENT() + CONSIDER_ONGOING + "\n\n" + PLEASE_ASSOFF;
+                    await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+                }
+                else if (_generalStorage.ManualRaidSilence)
+                {
+                    var msg = TIME_SINCE_LARGE() + ", but `.ass` was run in the meantime" + CONSIDER_ONGOING + "\n\n" + PLEASE_ASSOFF;
+                    await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+                }
+                else
+                {
+                    _log.Log("Ending large raid");
+
+                    _generalStorage.CurrentRaidMode = RaidMode.None;
+                    await FileHelper.SaveGeneralStorageAsync(_generalStorage);
+
+                    _config.AutoSilenceNewJoins = false;
+                    await FileHelper.SaveConfigAsync(_config);
+
+                    var msg = TIME_SINCE_LARGE() + ", " + AND_ONLY_RECENT() + CONSIDER_OVER + " " + ALARMS_ACTIVE;
+                    await _modLog.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+                }
+            });
     }
 
     public async Task ProcessMemberJoin(SocketGuildUser member)
     {
         if (member.Guild.Id != DiscordHelper.DefaultGuild()) return; // Don't process non-default server.
         if (!_config.RaidProtectionEnabled) return;
-        if (!UserRecentlyJoined(member.Id))
+        if (_state.RecentJoins.Contains(member.Id))
         {
-            _state.CurrentSmallJoinCount++;
-            _log.Log(
-                $"Small raid join count raised for {member.DisplayName} ({member.Id}). Now at {_state.CurrentSmallJoinCount}/{_config.SmallRaidSize} for {_config.SmallRaidTime} seconds.",
-                level: LogLevel.Debug);
-            _state.CurrentLargeJoinCount++;
-            _log.Log(
-                $"Large raid join count raised for {member.DisplayName} ({member.Id}). Now at {_state.CurrentLargeJoinCount}/{_config.LargeRaidSize} for {_config.LargeRaidTime} seconds.",
-                level: LogLevel.Debug);
-
-            _state.RecentJoins.Add(member.Id);
-
-            _log.Log(
-                $"{member.DisplayName} ({member.Id}) will be considered a recent join for the next {_config.RecentJoinDecay} seconds.");
-
-            await CheckForTrip(member.Guild);
-
-            var _ = Task.Run(async () =>
-            {
-                await Task.Delay(Convert.ToInt32(_config.SmallRaidTime * 1000));
-                _state.CurrentSmallJoinCount--;
-                _log.Log(
-                    $"Small raid join count dropped for {member.DisplayName} ({member.Id}). Now at {_state.CurrentSmallJoinCount}/{_config.SmallRaidSize} after {_config.SmallRaidTime} seconds.",
-                    level: LogLevel.Debug);
-            });
-
-            _ = Task.Run(async () =>
-            {
-                await Task.Delay(Convert.ToInt32(_config.LargeRaidTime * 1000));
-                _state.CurrentLargeJoinCount--;
-                _log.Log(
-                    $"Large raid join count dropped for {member.DisplayName} ({member.Id}). Now at {_state.CurrentLargeJoinCount}/{_config.LargeRaidSize} after {_config.LargeRaidTime} seconds.",
-                    level: LogLevel.Debug);
-            });
-
-            _ = Task.Run(async () =>
-            {
-                await Task.Delay(Convert.ToInt32(_config.RecentJoinDecay * 1000));
-                if (_generalStorage.CurrentRaidMode == RaidMode.None)
-                {
-                    _log.Log(
-                        $"{member.DisplayName} ({member.Id}) no longer a recent join");
-                    _state.RecentJoins.Remove(member.Id);
-                }
-            });
-            if (_config.SmallRaidDecay != null)
-                _ = Task.Run(async () =>
-                {
-                    await Task.Delay(Convert.ToInt32(_config.SmallRaidDecay * 60 * 1000));
-                    if (_config.SmallRaidDecay == null) return; // Was disabled
-                    if (_generalStorage.CurrentRaidMode != RaidMode.Small) return; // Not a small raid
-                    if (_state.CurrentSmallJoinCount > 0)
-                        return; // Small raid join count is still ongoing.
-                    if (_generalStorage.ManualRaidSilence) return; // This raid was manually silenced. Don't decay.
-
-                    _log.Log("Decaying raid: Small -> None", level: LogLevel.Debug);
-                    await DecaySmallRaid(member.Guild);
-                });
-            if (_config.LargeRaidDecay != null)
-                _ = Task.Run(async () =>
-                {
-                    await Task.Delay(Convert.ToInt32(_config.LargeRaidDecay * 60 * 1000));
-                    if (_config.SmallRaidDecay == null) return; // Was disabled
-                    if (_generalStorage.CurrentRaidMode != RaidMode.Large) return; // Not a large raid
-                    if (_state.CurrentLargeJoinCount > _config.SmallRaidSize)
-                        return; // Large raid join count is still ongoing.
-
-                    _log.Log("Decaying raid: Large -> Small", level: LogLevel.Debug);
-                    await DecayLargeRaid(member.Guild);
-                });
+            _log.Log($"{member.DisplayName}#{member.Discriminator} ({member.Id}) rejoined while still considered a recent join. Not updating recent joins list.");
+            return;
         }
-        else
-        {
-            _log.Log(
-                $"{member.DisplayName}#{member.Discriminator} ({member.Id}) rejoined while still considered a recent join. Not calculating additional raid pressure.");
-        }
+
+        _state.RecentJoins.Add(member.Id);
+        var recentJoins = GetRecentJoins(member.Guild);
+
+        if (recentJoins.Count >= _config.SmallRaidSize && _generalStorage.CurrentRaidMode == RaidMode.None)
+            await TripSmallRaid(member.Guild, recentJoins);
+        else if (recentJoins.Count >= _config.LargeRaidSize && _generalStorage.CurrentRaidMode != RaidMode.Large)
+            await TripLargeRaid(member.Guild, recentJoins);
     }
 }
 

--- a/Izzy-Moonbot/Settings/Config.cs
+++ b/Izzy-Moonbot/Settings/Config.cs
@@ -67,10 +67,8 @@ public class Config
         RaidProtectionEnabled = true;
         AutoSilenceNewJoins = false;
         SmallRaidSize = 3;
-        SmallRaidTime = 180;
-        LargeRaidSize = 10;
-        LargeRaidTime = 120;
-        RecentJoinDecay = 300;
+        LargeRaidSize = 6;
+        RecentJoinDecay = 120;
         SmallRaidDecay = 5;
         LargeRaidDecay = 30;
     }
@@ -151,9 +149,7 @@ public class Config
     public bool RaidProtectionEnabled { get; set; }
     public bool AutoSilenceNewJoins { get; set; }
     public int SmallRaidSize { get; set; }
-    public double SmallRaidTime { get; set; }
     public int LargeRaidSize { get; set; }
-    public double LargeRaidTime { get; set; }
     public double RecentJoinDecay { get; set; }
     public double? SmallRaidDecay { get; set; }
     public double? LargeRaidDecay { get; set; }

--- a/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
@@ -667,29 +667,15 @@ public class ConfigCommandTests
         Assert.AreEqual(cfg.SmallRaidSize, 5);
         Assert.AreEqual("I've set `SmallRaidSize` to the following content: 5", generalChannel.Messages.Last().Content);
 
-        // post ".config SmallRaidTime 50"
-        Assert.AreEqual(cfg.SmallRaidTime, 180);
-        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config SmallRaidTime 50");
-        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "SmallRaidTime", "50");
-        Assert.AreEqual(cfg.SmallRaidTime, 50);
-        Assert.AreEqual("I've set `SmallRaidTime` to the following content: 50", generalChannel.Messages.Last().Content);
-
         // post ".config LargeRaidSize 20"
-        Assert.AreEqual(cfg.LargeRaidSize, 10);
+        Assert.AreEqual(cfg.LargeRaidSize, 6);
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config LargeRaidSize 20");
         await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "LargeRaidSize", "20");
         Assert.AreEqual(cfg.LargeRaidSize, 20);
         Assert.AreEqual("I've set `LargeRaidSize` to the following content: 20", generalChannel.Messages.Last().Content);
 
-        // post ".config LargeRaidTime 200"
-        Assert.AreEqual(cfg.LargeRaidTime, 120);
-        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config LargeRaidTime 200");
-        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "LargeRaidTime", "200");
-        Assert.AreEqual(cfg.LargeRaidTime, 200);
-        Assert.AreEqual("I've set `LargeRaidTime` to the following content: 200", generalChannel.Messages.Last().Content);
-
         // post ".config RecentJoinDecay 100"
-        Assert.AreEqual(cfg.RecentJoinDecay, 300);
+        Assert.AreEqual(cfg.RecentJoinDecay, 120);
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config RecentJoinDecay 100");
         await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "RecentJoinDecay", "100");
         Assert.AreEqual(cfg.RecentJoinDecay, 100);
@@ -713,7 +699,7 @@ public class ConfigCommandTests
         // Ensure we can't forget to keep this test up to date
         var configPropsCount = typeof(Config).GetProperties().Length;
 
-        Assert.AreEqual(49, configPropsCount,
+        Assert.AreEqual(47, configPropsCount,
             $"\nIf you just added or removed a config item, then this test is probably out of date");
 
         Assert.AreEqual(configPropsCount * 2, generalChannel.Messages.Count(),

--- a/Izzy-MoonbotTests/Tests/FileHelperTests.cs
+++ b/Izzy-MoonbotTests/Tests/FileHelperTests.cs
@@ -192,6 +192,89 @@ public class FileHelperTests
 
         var config = JsonConvert.DeserializeObject<Config>(testConfig);
         var serialized = JsonConvert.SerializeObject(config, Formatting.Indented);
-        Assert.AreEqual(testConfig, serialized);
+
+        // testConfig with Small/LargeRaidTime removed
+        Assert.AreEqual("""
+            {
+              "Prefix": ".",
+              "UnicycleInterval": 100,
+              "MentionResponseEnabled": true,
+              "MentionResponses": [
+                "ohayo sekai good morning world",
+                "???"
+              ],
+              "MentionResponseCooldown": 10.0,
+              "DiscordActivityName": "you all soon",
+              "DiscordActivityWatching": true,
+              "Aliases": {
+                "testalias": "echo Test successful!",
+                "aliasfail": "",
+                "member": "assignrole <@&973220758736216084>",
+                "a": "ass"
+              },
+              "FirstRuleMessageId": 994643448948850788,
+              "HiddenRules": {
+                "-1": "<a:twiactually:613109204118667293>",
+                "test": "hello"
+              },
+              "BannerMode": 0,
+              "BannerInterval": 1.0,
+              "BannerImages": [
+                "test1",
+                "test2",
+                "test3",
+                "test4",
+                "test5",
+                "test6"
+              ],
+              "ModRole": 964283794083446804,
+              "ModChannel": 973218854237007963,
+              "LogChannel": 964283764240973844,
+              "ManageNewUserRoles": true,
+              "MemberRole": 965978050229571634,
+              "NewMemberRole": 1039194817231601695,
+              "NewMemberRoleDecay": 120.0,
+              "RolesToReapplyOnRejoin": [],
+              "FilterEnabled": true,
+              "FilterIgnoredChannels": [
+                964283764240973844
+              ],
+              "FilterBypassRoles": [
+                964283794083446804
+              ],
+              "FilterDevBypass": false,
+              "FilterWords": [
+                "magic",
+                "wing",
+                "feather",
+                "mayonnaise"
+              ],
+              "SpamEnabled": true,
+              "SpamBypassRoles": [
+                964283794083446804
+              ],
+              "SpamIgnoredChannels": [
+                964283764240973844
+              ],
+              "SpamDevBypass": true,
+              "SpamBasePressure": 10.0,
+              "SpamImagePressure": 8.3,
+              "SpamLengthPressure": 0.00625,
+              "SpamLinePressure": 2.8,
+              "SpamPingPressure": 2.5,
+              "SpamRepeatPressure": 20.0,
+              "SpamUnusualCharacterPressure": 0.01,
+              "SpamMaxPressure": 60.0,
+              "SpamPressureDecay": 2.5,
+              "SpamMessageDeleteLookback": 60.0,
+              "RaidProtectionEnabled": false,
+              "AutoSilenceNewJoins": false,
+              "SmallRaidSize": 3,
+              "LargeRaidSize": 10,
+              "RecentJoinDecay": 300.0,
+              "SmallRaidDecay": 5.0,
+              "LargeRaidDecay": 30.0
+            }
+            """, serialized);
     }
 }

--- a/ManualTestingScript.md
+++ b/ManualTestingScript.md
@@ -42,6 +42,13 @@ Because this is a *manual* testing script, the goal is not be comprehensive cove
 
 - `.ban <your alt> 10 seconds`, which should remove your alt from the server, post messages and mod logs, then later allow the alt to rejoin
 
-- `.wipe <#963788928702373918> 10 minutes`, which should delete most of the messages you just produced, post a bulk deletion log and link to it
+- small raids (you'd need at least two alts to test a large raid)
+	- make sure your test values for `.config SmallRaidDecay` and `.config RecentJoinDecay` are low (e.g. `1` and `10`), so this will involve less waiting, and that `.config RaidProtectionEnabled` is `true`
+	- run `.config SmallRaidSize 1`
+	- make your alt (re)join, which should post a raid message
+	- wait 1 minute for the "raid" to end, which should post another message
+	- either do `.config RaidProtectionEnabled false` or change `.config SmallRaidSize` back to a more reasonable value
+
+- `.wipe <#963788928702373918> 20 minutes`, which should delete most of the messages you just produced, post a bulk deletion log and link to it
 
 (we don't have a great way to repeatedly test raids right now; even the `.test raid` command requires seveal real user ids which would then get silenced and that's a mess to clean up)


### PR DESCRIPTION
Might as well quote what I said in #modchat:

> My proposal: Conceptually: Redefine a "raid" to just be "3 (or 6) recent joins". Concretely: Remove the Small/LargeRaidTime settings. Lower RecentJoinDecay to 120 so the conditions for a "small raid" are exactly the same as before. Lower LargeRaidSize from 10 to 6 so a "large raid" is roughly the same as before (10 * 120/180 = 6.66...).
> 
> This will also make Izzy's raid implementation significantly simpler and more robust, because she would only need to track one set of users with at most one timer.

This also made it relatively easy for me to make Izzy's raid notifications much more accurate, such as varying the text based on whether someone already ran `.ass`.

Part 2 of #341, probably out of 3