### PR TITLE
miscellaneous quote changes

### DIFF
--- a/Izzy-Moonbot/Modules/MiscModule.cs
+++ b/Izzy-Moonbot/Modules/MiscModule.cs
@@ -27,8 +27,9 @@ public class MiscModule : ModuleBase<SocketCommandContext>
     private readonly ModLoggingService _modLog;
     private readonly CommandService _commands;
     private readonly GeneralStorage _generalStorage;
+    private readonly QuoteService _quoteService;
 
-    public MiscModule(Config config, ConfigDescriber configDescriber, ScheduleService schedule, LoggingService logger, ModLoggingService modLog, CommandService commands, GeneralStorage generalStorage)
+    public MiscModule(Config config, ConfigDescriber configDescriber, ScheduleService schedule, LoggingService logger, ModLoggingService modLog, CommandService commands, GeneralStorage generalStorage, QuoteService quoteService)
     {
         _config = config;
         _configDescriber = configDescriber;
@@ -37,6 +38,7 @@ public class MiscModule : ModuleBase<SocketCommandContext>
         _modLog = modLog;
         _commands = commands;
         _generalStorage = generalStorage;
+        _quoteService = quoteService;
     }
 
     [Command("banner")]
@@ -381,6 +383,14 @@ public class MiscModule : ModuleBase<SocketCommandContext>
             ponyReadable += PonyReadableCommandHelp(prefix, item, commandInfo);
             ponyReadable += PonyReadableSelfSearch(item, isMod, isDev);
             await context.Channel.SendMessageAsync(ponyReadable);
+        }
+        // Try quote aliases
+        else if (_quoteService.AliasExists(item))
+        {
+            var user = _quoteService.ProcessAlias(item, context.Guild);
+
+            await context.Channel.SendMessageAsync($"'{item}' is a quotealias for the user <@{user.Id}>. Use `.listquotes {item}` or `.quote {item}` to see their quotes." +
+                "\n\nSee `.help quote` and `.help quotelias` for more information.");
         }
         else
         {

--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -65,12 +65,9 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             return;
         }
 
-        ulong userId;
-        if (_quoteService.AliasExists(search))
-            userId = _quoteService.ProcessAlias(search, defaultGuild).Id;
-        else
-            userId = await DiscordHelper.GetUserIdFromPingOrIfOnlySearchResultAsync(search, context, true);
-
+        ulong userId = _quoteService.AliasExists(search)
+            ? _quoteService.ProcessAlias(search, defaultGuild).Id
+            : await DiscordHelper.GetUserIdFromPingOrIfOnlySearchResultAsync(search, context, true);
         if (userId == 0)
         {
             await context.Channel.SendMessageAsync("I was unable to find the user you asked for. Sorry!");
@@ -315,7 +312,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
         {
             var quoteUser = _quoteService.ProcessAlias(user, context.Guild);
 
-            var newAliasUserQuote = await _quoteService.RemoveQuote(quoteUser, number.Value - 1);
+            await _quoteService.RemoveQuote(quoteUser, number.Value - 1);
 
             await context.Channel.SendMessageAsync(
                 $"Removed quote number {number.Value} from **{quoteUser.Username}#{quoteUser.Discriminator}**.", allowedMentions: AllowedMentions.None);

--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -63,61 +63,18 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             return;
         }
 
+        // Get random quote from a specific user
         if (search != "" && number == null)
         {
-            // Get random quote depending on if search is user-resolvable or not
             // First check if the search resolves to an alias.
-
             if (_quoteService.AliasExists(search))
             {
-                // This is an alias, check what type
-                if (_quoteService.AliasRefersTo(search, defaultGuild) == "user")
-                {
-                    // The alias refers to an existing user. 
-                    var user = _quoteService.ProcessAlias(search, defaultGuild);
+                var user = _quoteService.ProcessAlias(search, defaultGuild);
 
-                    // Choose a random quote from this user.
-                    try
-                    {
-                        var quote = _quoteService.GetRandomQuote(user);
-
-                        // Send quote and return
-                        await context.Channel.SendMessageAsync($"**{quote.Name} `#{quote.Id + 1}`:** {quote.Content}", allowedMentions: AllowedMentions.None);
-                        return;
-                    }
-                    catch (NullReferenceException)
-                    {
-                        await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
-                        return;
-                    }
-                }
-
-                // This alias refers to a category or user who left.
-                var category = _quoteService.ProcessAlias(search);
-
-                // Choose a random quote from this category.
+                // Choose a random quote from this user.
                 try
                 {
-                    var quote = _quoteService.GetRandomQuote(category);
-
-                    // Send quote and return.
-                    await context.Channel.SendMessageAsync($"**{quote.Name} `#{quote.Id + 1}`:** {quote.Content}", allowedMentions: AllowedMentions.None);
-                    return;
-                }
-                catch (NullReferenceException)
-                {
-                    await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
-                    return;
-                }
-            }
-            // This isn't an alias. Check if this is a category.
-            if (_quoteService.CategoryExists(search))
-            {
-                // It is, this either refers to a category or a user who left.
-                // Get a random quote from the category
-                try
-                {
-                    var quote = _quoteService.GetRandomQuote(search);
+                    var quote = _quoteService.GetRandomQuote(user);
 
                     // Send quote and return
                     await context.Channel.SendMessageAsync($"**{quote.Name} `#{quote.Id + 1}`:** {quote.Content}", allowedMentions: AllowedMentions.None);
@@ -125,18 +82,16 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                 }
                 catch (NullReferenceException)
                 {
-                    await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
+                    await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
                     return;
                 }
             }
-            // It isn't, this is a user.
+
+            // Not an alias, search for a user.
             var userId = await DiscordHelper.GetUserIdFromPingOrIfOnlySearchResultAsync(search, context, true);
             var member = defaultGuild.GetUser(userId);
-
-            // Check if the user exists or not
             if (member == null)
             {
-                // They don't, send a fail message and return.
                 await context.Channel.SendMessageAsync("I was unable to find the user you asked for. Sorry!");
                 return;
             }
@@ -157,6 +112,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             }
         }
 
+        // Get specific quote from a specific user
         if (search != "" && number != null)
         {
             if (number.Value <= 0)
@@ -165,65 +121,15 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                 return;
             }
 
+            // First check if the search resolves to an alias.
             if (_quoteService.AliasExists(search))
             {
-                // This is an alias, check what type
-                if (_quoteService.AliasRefersTo(search, defaultGuild) == "user")
-                {
-                    // The alias refers to an existing user. 
-                    var user = _quoteService.ProcessAlias(search, defaultGuild);
+                var user = _quoteService.ProcessAlias(search, defaultGuild);
 
-                    // Choose a random quote from this user.
-                    try
-                    {
-                        var quote = _quoteService.GetQuote(user, number.Value - 1);
-
-                        // Send quote and return
-                        await context.Channel.SendMessageAsync($"**{quote.Name} `#{quote.Id + 1}`:** {quote.Content}", allowedMentions: AllowedMentions.None);
-                        return;
-                    }
-                    catch (NullReferenceException)
-                    {
-                        await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
-                        return;
-                    }
-                    catch (IndexOutOfRangeException)
-                    {
-                        await context.Channel.SendMessageAsync($"I couldn't find that quote, sorry!");
-                        return;
-                    }
-                }
-                // This alias refers to a category or user who left.
-                var category = _quoteService.ProcessAlias(search);
-
-                // Choose a random quote from this category.
+                // Choose a random quote from this user.
                 try
                 {
-                    var quote = _quoteService.GetQuote(category, number.Value - 1);
-
-                    // Send quote and return.
-                    await context.Channel.SendMessageAsync($"**{quote.Name} `#{quote.Id + 1}`:** {quote.Content}", allowedMentions: AllowedMentions.None);
-                    return;
-                }
-                catch (NullReferenceException)
-                {
-                    await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
-                    return;
-                }
-                catch (IndexOutOfRangeException)
-                {
-                    await context.Channel.SendMessageAsync($"I couldn't find that quote, sorry!");
-                    return;
-                }
-            }
-            // This isn't an alias. Check if this is a category.
-            if (_quoteService.CategoryExists(search))
-            {
-                // It is, this either refers to a category or a user who left.
-                // Get a random quote from the category
-                try
-                {
-                    var quote = _quoteService.GetQuote(search, number.Value - 1);
+                    var quote = _quoteService.GetQuote(user, number.Value - 1);
 
                     // Send quote and return
                     await context.Channel.SendMessageAsync($"**{quote.Name} `#{quote.Id + 1}`:** {quote.Content}", allowedMentions: AllowedMentions.None);
@@ -231,7 +137,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                 }
                 catch (NullReferenceException)
                 {
-                    await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
+                    await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
                     return;
                 }
                 catch (IndexOutOfRangeException)
@@ -240,14 +146,12 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                     return;
                 }
             }
-            // It isn't, this is a user.
+
+            // Not an alias, search for a user.
             var userId = await DiscordHelper.GetUserIdFromPingOrIfOnlySearchResultAsync(search, context, true);
             var member = defaultGuild.GetUser(userId);
-
-            // Check if the user exists or not
             if (member == null)
             {
-                // They don't, send a fail message and return.
                 await context.Channel.SendMessageAsync("I was unable to find the user you asked for. Sorry!");
                 return;
             }
@@ -263,7 +167,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             }
             catch (NullReferenceException)
             {
-                await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
+                await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
                 return;
             }
             catch (IndexOutOfRangeException)
@@ -277,14 +181,11 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
     }
 
     [Command("listquotes")]
-    [Summary(
-        "List all the quotes for a specific user or category, or list all the users and categories that have quotes if one is not provided.")]
+    [Summary("List all the quotes for a specific user, or list all the users that have quotes.")]
     [Alias("lq", "searchquotes", "searchquote", "sq")]
     [Parameter("user", ParameterType.UserResolvable, "The user to search for.", true)]
     [ExternalUsageAllowed]
-    public async Task ListQuotesCommandAsync(
-        [Remainder] string search = ""
-    )
+    public async Task ListQuotesCommandAsync([Remainder] string search = "")
     {
         await TestableListQuotesCommandAsync(
             new SocketCommandContextAdapter(Context),
@@ -305,62 +206,31 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
             PaginationHelper.PaginateIfNeededAndSendMessage(
                 context,
-                "Here's a list of users/categories of quotes I've found.",
+                "Here's all the users who have quotes.",
                 quoteKeys,
-                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category if specified.\n" +
-                $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                $"Run `{_config.Prefix}quote <user>` to get a random quote from that user.\n" +
+                $"Run `{_config.Prefix}quote` for a random quote from a random user.",
                 pageSize: 15,
                 allowedMentions: AllowedMentions.None
             );
             return;
         }
 
-        // Search for user/category
         if (_quoteService.AliasExists(search))
         {
-            // This is an alias, check what type
-            if (_quoteService.AliasRefersTo(search, defaultGuild) == "user")
-            {
-                // The alias refers to an existing user. 
-                var user = _quoteService.ProcessAlias(search, defaultGuild);
+            var user = _quoteService.ProcessAlias(search, defaultGuild);
 
-                try
-                {
-                    var quotes = _quoteService.GetQuotes(user).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
-
-                    PaginationHelper.PaginateIfNeededAndSendMessage(
-                        context,
-                        $"Here's all the quotes I could find for **{user.Username}#{user.Discriminator}**.",
-                        quotes,
-                        $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
-                        $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
-                        $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
-                        pageSize: 15,
-                        allowedMentions: AllowedMentions.None
-                    );
-                    return;
-                }
-                catch (NullReferenceException)
-                {
-                    await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
-                    return;
-                }
-            }
-            // This alias refers to a category or user who left.
-            var category = _quoteService.ProcessAlias(search);
-
-            // Choose a random quote from this category.
             try
             {
-                var quotes = _quoteService.GetQuotes(category).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
+                var quotes = _quoteService.GetQuotes(user).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
 
                 PaginationHelper.PaginateIfNeededAndSendMessage(
                     context,
-                    $"Here's all the quotes I could find in **{category}**.",
+                    $"Here's all the quotes I have for **{user.Username}#{user.Discriminator}**.",
                     quotes,
-                    $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
-                    $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
-                    $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                    $"Run `{_config.Prefix}quote <user> <number>` to get a specific quote.\n" +
+                    $"Run `{_config.Prefix}quote <user>` to get a random quote from that user.\n" +
+                    $"Run `{_config.Prefix}quote` for a random quote from a random user.",
                     pageSize: 15,
                     allowedMentions: AllowedMentions.None
                 );
@@ -368,45 +238,15 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             }
             catch (NullReferenceException)
             {
-                await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
+                await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
                 return;
             }
         }
-        // This isn't an alias. Check if this is a category.
-        if (_quoteService.CategoryExists(search))
-        {
-            // It is, this either refers to a category or a user who left.
-            // Get a random quote from the category
-            try
-            {
-                var quotes = _quoteService.GetQuotes(search).Select(quote => $"{quote.Id + 1}: {quote.Content}").ToArray();
 
-                PaginationHelper.PaginateIfNeededAndSendMessage(
-                    context,
-                    $"Here's all the quotes I could find in **{search}**.",
-                    quotes,
-                    $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
-                    $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
-                    $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
-                    pageSize: 15,
-                    allowedMentions: AllowedMentions.None
-                );
-                return;
-            }
-            catch (NullReferenceException)
-            {
-                await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
-                return;
-            }
-        }
-        // It isn't, this is a user.
         var userId = await DiscordHelper.GetUserIdFromPingOrIfOnlySearchResultAsync(search, context, true);
         var member = defaultGuild.GetUser(userId);
-
-        // Check if the user exists or not
         if (member == null)
         {
-            // They don't, send a fail message and return.
             await context.Channel.SendMessageAsync("I was unable to find the user you asked for. Sorry!");
             return;
         }
@@ -417,11 +257,11 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
             PaginationHelper.PaginateIfNeededAndSendMessage(
                 context,
-                $"Here's all the quotes I could find for **{member.DisplayName}**.",
+                $"Here's all the quotes I have for **{member.DisplayName}**.",
                 quotes,
-                $"Run `{_config.Prefix}quote <user/category> <number>` to get a specific quote.\n" +
-                $"Run `{_config.Prefix}quote <user/category>` to get a random quote from that user/category.\n" +
-                $"Run `{_config.Prefix}quote` for a random quote from a random user/category.",
+                $"Run `{_config.Prefix}quote <user> <number>` to get a specific quote.\n" +
+                $"Run `{_config.Prefix}quote <user>` to get a random quote from that user.\n" +
+                $"Run `{_config.Prefix}quote` for a random quote from a random user.",
                 pageSize: 15,
                 allowedMentions: AllowedMentions.None
             );
@@ -429,14 +269,13 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
         }
         catch (NullReferenceException)
         {
-            await context.Channel.SendMessageAsync($"I couldn't find any quotes in that category.");
+            await context.Channel.SendMessageAsync($"I couldn't find any quotes for that user.");
             return;
         }
     }
 
     [Command("addquote")]
-    [Summary(
-        "Adds a quote to a user or category.")]
+    [Summary("Adds a quote to a user.")]
     [ModCommand(Group = "Permission")]
     [DevCommand(Group = "Permission")]
     [Parameter("user", ParameterType.UserResolvable, "The user to add the quote to.")]
@@ -470,7 +309,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
         if (user == "")
         {
-            await context.Channel.SendMessageAsync("You need to tell me the user/category you want to add the quote to.");
+            await context.Channel.SendMessageAsync("You need to tell me the user you want to add the quote to.");
             return;
         }
 
@@ -494,36 +333,13 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
         // Check for aliases
         if (_quoteService.AliasExists(user))
         {
-            if (_quoteService.AliasRefersTo(user, context.Guild) == "user")
-            {
-                var quoteUser = _quoteService.ProcessAlias(user, context.Guild);
+            var quoteUser = _quoteService.ProcessAlias(user, context.Guild);
 
-                var newAliasUserQuote = await _quoteService.AddQuote(quoteUser, content);
-
-                await context.Channel.SendMessageAsync(
-                    $"Added the quote to **{quoteUser.Username}#{quoteUser.Discriminator}** as quote number {newAliasUserQuote.Id + 1}.\n" +
-                    $">>> {newAliasUserQuote.Content}", allowedMentions: AllowedMentions.None);
-                return;
-            }
-            var quoteCategory = _quoteService.ProcessAlias(user, context.Guild);
-
-            var newAliasCategoryQuote = await _quoteService.AddQuote(quoteCategory, content);
+            var newAliasUserQuote = await _quoteService.AddQuote(quoteUser, content);
 
             await context.Channel.SendMessageAsync(
-                $"Added the quote to **{newAliasCategoryQuote.Name}** as quote number {newAliasCategoryQuote.Id + 1}.\n" +
-                $">>> {newAliasCategoryQuote.Content}", allowedMentions: AllowedMentions.None);
-            return;
-        }
-
-        // Prioritise existing categories
-        if (_quoteService.CategoryExists(user))
-        {
-            // Category exists, add new quote to it.
-            var newCategoryQuote = await _quoteService.AddQuote(user, content);
-
-            await context.Channel.SendMessageAsync(
-                $"Added the quote to **{user}** as quote number {newCategoryQuote.Id + 1}.\n" +
-                $">>> {newCategoryQuote.Content}", allowedMentions: AllowedMentions.None);
+                $"Added the quote to **{quoteUser.Username}#{quoteUser.Discriminator}** as quote number {newAliasUserQuote.Id + 1}.\n" +
+                $">>> {newAliasUserQuote.Content}", allowedMentions: AllowedMentions.None);
             return;
         }
 
@@ -533,12 +349,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
         if (member == null)
         {
-            // New category
-            var newCategoryNewQuote = await _quoteService.AddQuote(user, content);
-
-            await context.Channel.SendMessageAsync(
-                $"Added the quote to **{user}** as quote number {newCategoryNewQuote.Id + 1}.\n" +
-                $">>> {newCategoryNewQuote.Content}", allowedMentions: AllowedMentions.None);
+            await context.Channel.SendMessageAsync("I was unable to find the user you asked for. Sorry!");
             return;
         }
 
@@ -551,8 +362,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
     }
 
     [Command("removequote")]
-    [Summary(
-        "Removes a quote from a user or category.")]
+    [Summary("Removes a quote from a user.")]
     [ModCommand(Group = "Permission")]
     [DevCommand(Group = "Permission")]
     [Alias("deletequote", "rmquote", "delquote")]
@@ -582,7 +392,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
         if (user == "")
         {
-            await context.Channel.SendMessageAsync("You need to tell me the user/category you want to remove the quote from.");
+            await context.Channel.SendMessageAsync("You need to tell me the user you want to remove the quote from.");
             return;
         }
 
@@ -601,33 +411,12 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
         // Check for aliases
         if (_quoteService.AliasExists(user))
         {
-            if (_quoteService.AliasRefersTo(user, context.Guild) == "user")
-            {
-                var quoteUser = _quoteService.ProcessAlias(user, context.Guild);
+            var quoteUser = _quoteService.ProcessAlias(user, context.Guild);
 
-                var newAliasUserQuote = await _quoteService.RemoveQuote(quoteUser, number.Value - 1);
-
-                await context.Channel.SendMessageAsync(
-                    $"Removed quote number {number.Value} from **{quoteUser.Username}#{quoteUser.Discriminator}**.", allowedMentions: AllowedMentions.None);
-                return;
-            }
-            var quoteCategory = _quoteService.ProcessAlias(user, context.Guild);
-
-            var newAliasCategoryQuote = await _quoteService.RemoveQuote(quoteCategory, number.Value - 1);
+            var newAliasUserQuote = await _quoteService.RemoveQuote(quoteUser, number.Value - 1);
 
             await context.Channel.SendMessageAsync(
-                $"Removed quote number {number.Value} from **{newAliasCategoryQuote.Name}**.", allowedMentions: AllowedMentions.None);
-            return;
-        }
-
-        // Prioritise existing categories
-        if (_quoteService.CategoryExists(user))
-        {
-            // Category exists, add new quote to it.
-            var newCategoryQuote = await _quoteService.RemoveQuote(user, number.Value - 1);
-
-            await context.Channel.SendMessageAsync(
-                $"Removed quote number {number.Value} from **{newCategoryQuote.Name}**.", allowedMentions: AllowedMentions.None);
+                $"Removed quote number {number.Value} from **{quoteUser.Username}#{quoteUser.Discriminator}**.", allowedMentions: AllowedMentions.None);
             return;
         }
 
@@ -637,8 +426,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
         if (member == null)
         {
-            await context.Channel.SendMessageAsync(
-                $"Sorry, I couldn't find that user");
+            await context.Channel.SendMessageAsync($"Sorry, I couldn't find that user");
             return;
         }
 
@@ -650,8 +438,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
     }
 
     [Command("quotealias")]
-    [Summary(
-        "Manage quote aliases.")]
+    [Summary("Manage quote aliases.")]
     [ModCommand(Group = "Permission")]
     [DevCommand(Group = "Permission")]
     [Parameter("operation", ParameterType.String, "The operation to complete (get/list/set/delete)")]
@@ -675,7 +462,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             await context.Channel.SendMessageAsync($"Hiya! This is how to use the quote alias command!\n" +
                              $"`{_config.Prefix}quotealias get <alias>` - Work out what an alias maps to.\n" +
                              $"`{_config.Prefix}quotealias list` - List all aliases.\n" +
-                             $"`{_config.Prefix}quotealias set/add <alias> <user/category>` - Creates an alias.\n" +
+                             $"`{_config.Prefix}quotealias set/add <alias> <user>` - Creates an alias.\n" +
                              $"`{_config.Prefix}quotealias delete/remove <alias>` - Deletes an alias.");
             return;
         }
@@ -694,7 +481,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                 $"Here's all the aliases I could find.\n```\n" +
                 $"{string.Join(", ", aliases)}\n```\n" +
                 $"Run `{_config.Prefix}quotealias get <alias>` to find out what an alias maps to.\n" +
-                $"Run `{_config.Prefix}quotealias set/add <alias> <user/category>` to create a new alias.\n" +
+                $"Run `{_config.Prefix}quotealias set/add <alias> <user>` to create a new alias.\n" +
                 $"Run `{_config.Prefix}quotealias delete/remove <alias>` to delete an alias.", allowedMentions: AllowedMentions.None);
         }
         else if (operation.ToLower() == "get")
@@ -707,20 +494,10 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
             if (_quoteService.AliasExists(alias))
             {
-                if (_quoteService.AliasRefersTo(alias, context.Guild) == "user")
-                {
-                    var user = _quoteService.ProcessAlias(alias, context.Guild);
+                var user = _quoteService.ProcessAlias(alias, context.Guild);
 
-                    await context.Channel.SendMessageAsync(
-                        $"Quote alias **{alias}** maps to user **{user.Username}#{user.Discriminator}**.", allowedMentions: AllowedMentions.None);
-                }
-                else
-                {
-                    var category = _quoteService.ProcessAlias(alias);
-
-                    await context.Channel.SendMessageAsync(
-                        $"Quote alias **{alias}** maps to category **{category}**.", allowedMentions: AllowedMentions.None);
-                }
+                await context.Channel.SendMessageAsync(
+                    $"Quote alias **{alias}** maps to user **{user.Username}#{user.Discriminator}**.", allowedMentions: AllowedMentions.None);
             }
         }
         else if (operation.ToLower() == "set" || operation.ToLower() == "add")
@@ -733,32 +510,22 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
             if (target == "")
             {
-                await context.Channel.SendMessageAsync("You need to provide a user or category name to set the alias to.");
+                await context.Channel.SendMessageAsync("You need to provide a user name to set the alias to.");
                 return;
             }
 
-            if (_quoteService.CategoryExists(target))
+            var userId = DiscordHelper.ConvertUserPingToId(target);
+            var member = context.Guild?.GetUser(userId);
+
+            if (member == null)
             {
-                await _quoteService.AddAlias(alias, target);
-
-                await context.Channel.SendMessageAsync($"Added alias **{alias}** to map to category **{target}**.", allowedMentions: AllowedMentions.None);
+                await context.Channel.SendMessageAsync($"I couldn't find a user with the target you provided.");
+                return;
             }
-            else
-            {
-                var userId = DiscordHelper.ConvertUserPingToId(target);
-                var member = context.Guild?.GetUser(userId);
 
-                if (member == null)
-                {
-                    // Category
-                    await context.Channel.SendMessageAsync($"I couldn't find a user or category with the target you provided.");
-                    return;
-                }
+            await _quoteService.AddAlias(alias, member);
 
-                await _quoteService.AddAlias(alias, member);
-
-                await context.Channel.SendMessageAsync($"Added alias **{alias}** to map to user **{target}**.", allowedMentions: AllowedMentions.None);
-            }
+            await context.Channel.SendMessageAsync($"Added alias **{alias}** to map to user **{target}**.", allowedMentions: AllowedMentions.None);
         }
         else if (operation.ToLower() == "delete" || operation.ToLower() == "remove")
         {
@@ -773,8 +540,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
         }
         else
         {
-            await context.Channel.SendMessageAsync(
-                "Sorry, I don't understand what you want me to do.");
+            await context.Channel.SendMessageAsync("Sorry, I don't understand what you want me to do.");
         }
     }
 }

--- a/Izzy-Moonbot/Service/QuoteService.cs
+++ b/Izzy-Moonbot/Service/QuoteService.cs
@@ -139,26 +139,12 @@ public class QuoteService
         return new Quote(id, quoteName, quoteContent);
     }
 
-    /// <summary>
-    /// Get a list of quotes from a valid Discord user.
-    /// </summary>
-    /// <param name="user">The user to get the quotes of.</param>
-    /// <returns>An array of Quotes that this user has.</returns>
-    /// <exception cref="NullReferenceException">If the user doesn't have any quotes.</exception>
-    public Quote[] GetQuotes(IIzzyUser user)
+    public List<string>? GetQuotes(ulong userId)
     {
-        if (!_quoteStorage.Quotes.ContainsKey(user.Id.ToString()))
-            throw new NullReferenceException("That user does not have any quotes.");
-        
-        var quotes = _quoteStorage.Quotes[user.Id.ToString()].Select((content, index) =>
-        {
-            var quoteName = user.Username;
-            if (user is IGuildUser guildUser) quoteName = guildUser.DisplayName;
+        if (!_quoteStorage.Quotes.ContainsKey(userId.ToString()))
+            return null;
 
-            return new Quote(index, quoteName, content);
-        }).ToArray();
-
-        return quotes;
+        return _quoteStorage.Quotes[userId.ToString()];
     }
 
     /// <summary>

--- a/Izzy-Moonbot/Settings/QuoteStorage.cs
+++ b/Izzy-Moonbot/Settings/QuoteStorage.cs
@@ -7,7 +7,7 @@ public class QuoteStorage
     public QuoteStorage()
     {
         Quotes = new Dictionary<
-            string, // either a stringified user id, or a category name
+            string, // a stringified user id
             List<string>
         >();
         Aliases = new Dictionary<string, string>();

--- a/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
@@ -68,9 +68,12 @@ public class MiscModuleTests
         var logger = new LoggingService(new TestLogger<Worker>());
         var ss = new ScheduleService(cfg, mod, modLog, logger, scheduledJobs);
         var gs = new GeneralStorage();
+        var quotes = new QuoteStorage();
+        var userinfo = new Dictionary<ulong, User>();
+        var qs = new QuoteService(quotes, userinfo);
 
         var cfgDescriber = new ConfigDescriber();
-        return (ss, new MiscModule(cfg, cfgDescriber, ss, logger, modLog, await SetupCommandService(), gs));
+        return (ss, new MiscModule(cfg, cfgDescriber, ss, logger, modLog, await SetupCommandService(), gs, qs));
     }
 
     [TestMethod()]

--- a/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
@@ -346,7 +346,7 @@ public class MiscModuleTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "**.rmquote** (alternate name of **.removequote**) - Quotes category", null, null);
         StringAssert.Contains(description, "ℹ  *This is a moderator", null, null);
-        StringAssert.Contains(description, "*Removes a quote from a user or category", null, null);
+        StringAssert.Contains(description, "*Removes a quote from a user", null, null);
         StringAssert.Contains(description, "Syntax: `.removequote user id`", null, null);
         StringAssert.Contains(description, "user [User ID", null, null);
         StringAssert.Contains(description, "id [Integer]", null, null);

--- a/Izzy-MoonbotTests/Tests/ModMiscModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/ModMiscModuleTests.cs
@@ -63,7 +63,10 @@ public class ModMiscModuleTests
         var cfgDescriber = new ConfigDescriber();
         var modLog = new ModLoggingService(cfg);
         var gs = new GeneralStorage();
-        var mm = new MiscModule(cfg, cfgDescriber, ss, logger, modLog, await MiscModuleTests.SetupCommandService(), gs);
+        var quotes = new QuoteStorage();
+        var userinfo = new Dictionary<ulong, User>();
+        var qs = new QuoteService(quotes, userinfo);
+        var mm = new MiscModule(cfg, cfgDescriber, ss, logger, modLog, await MiscModuleTests.SetupCommandService(), gs, qs);
 
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".schedule");

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -85,7 +85,7 @@ public class QuoteModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, "for **Izzy Moonbot**");
+        StringAssert.Contains(description, $"for <@{izzy.Id}>");
         StringAssert.Contains(description, $"```\n" +
             $"1: let's unicycle it\n" +
             $"```\n");
@@ -98,7 +98,7 @@ public class QuoteModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, "for **Sunny**");
+        StringAssert.Contains(description, $"for <@{sunny.Id}>");
         StringAssert.Contains(description, $"```\n" +
             $"1: gonna be my day\n" +
             $"2: eat more vegetables\n" +
@@ -163,7 +163,7 @@ public class QuoteModuleTests
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, "for **Sunny**");
+        StringAssert.Contains(description, $"for <@{sunny.Id}>");
         StringAssert.Contains(description, $"```\n" +
             $"1: gonna be my day\n" +
             $"2: gonna be my day\n" +

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -25,19 +25,19 @@ public class QuoteModuleTests
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote");
         await qm.TestableQuoteCommandAsync(context, "");
-        Assert.AreEqual("**Sunny `#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote Sunny");
         await qm.TestableQuoteCommandAsync(context, "Sunny");
-        Assert.AreEqual("**Sunny `#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}>");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}>");
-        Assert.AreEqual("**Sunny `#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}> 1");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}> 1");
-        Assert.AreEqual("**Sunny `#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}> 2");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}> 2");
@@ -46,7 +46,7 @@ public class QuoteModuleTests
         // Zipp has no quotes because she never appeared on the pippcast
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote Zipp");
         await qm.TestableQuoteCommandAsync(context, "Zipp");
-        Assert.AreEqual("I couldn't find any for that user.", generalChannel.Messages.Last().Content);
+        Assert.AreEqual("I couldn't find any quotes for that user.", generalChannel.Messages.Last().Content);
 
         // Twi didn't make it to G5
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote Twilight");

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -72,12 +72,12 @@ public class QuoteModuleTests
         await qm.TestableListQuotesCommandAsync(context, "");
 
         var description = generalChannel.Messages.Last().Content;
-        StringAssert.Contains(description, "Here's a list of");
+        StringAssert.Contains(description, "Here's all the");
         StringAssert.Contains(description, $"```\n" +
             $"Sunny (Sunny#1234) \n" +
             $"Izzy Moonbot (Izzy Moonbot#1234) \n" +
             $"```\n");
-        StringAssert.Contains(description, "Run `.quote <user/category>`");
+        StringAssert.Contains(description, "Run `.quote <user>`");
         StringAssert.Contains(description, "Run `.quote`");
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Izzy");
@@ -89,8 +89,8 @@ public class QuoteModuleTests
         StringAssert.Contains(description, $"```\n" +
             $"1: let's unicycle it\n" +
             $"```\n");
-        StringAssert.Contains(description, "Run `.quote <user/category> <number>` to");
-        StringAssert.Contains(description, "Run `.quote <user/category>` to");
+        StringAssert.Contains(description, "Run `.quote <user> <number>` to");
+        StringAssert.Contains(description, "Run `.quote <user>` to");
         StringAssert.Contains(description, "Run `.quote` for");
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Sunny");
@@ -103,14 +103,14 @@ public class QuoteModuleTests
             $"1: gonna be my day\n" +
             $"2: eat more vegetables\n" +
             $"```\n");
-        StringAssert.Contains(description, "Run `.quote <user/category> <number>` to");
-        StringAssert.Contains(description, "Run `.quote <user/category>` to");
+        StringAssert.Contains(description, "Run `.quote <user> <number>` to");
+        StringAssert.Contains(description, "Run `.quote <user>` to");
         StringAssert.Contains(description, "Run `.quote` for");
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Zipp");
         await qm.TestableListQuotesCommandAsync(context, "Zipp");
 
-        Assert.AreEqual("I couldn't find any quotes in that category.", generalChannel.Messages.Last().Content);
+        Assert.AreEqual("I couldn't find any quotes for that user.", generalChannel.Messages.Last().Content);
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Twilight");
         await qm.TestableListQuotesCommandAsync(context, "Twilight");
@@ -136,11 +136,11 @@ public class QuoteModuleTests
         await qm.TestableListQuotesCommandAsync(context, "");
 
         var description = generalChannel.Messages.Last().Content;
-        StringAssert.Contains(description, "Here's a list of");
+        StringAssert.Contains(description, "Here's all the");
         StringAssert.Contains(description, $"```\n" +
             $"1234 \n" +
             $"```\n");
-        StringAssert.Contains(description, "Run `.quote <user/category>`");
+        StringAssert.Contains(description, "Run `.quote <user>`");
         StringAssert.Contains(description, "Run `.quote`");
     }
 
@@ -168,8 +168,8 @@ public class QuoteModuleTests
             $"1: gonna be my day\n" +
             $"2: gonna be my day\n" +
             $"```\n");
-        StringAssert.Contains(description, "Run `.quote <user/category> <number>` to");
-        StringAssert.Contains(description, "Run `.quote <user/category>` to");
+        StringAssert.Contains(description, "Run `.quote <user> <number>` to");
+        StringAssert.Contains(description, "Run `.quote <user>` to");
         StringAssert.Contains(description, "Run `.quote` for");
     }
 

--- a/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
@@ -24,13 +24,11 @@ public class QuoteServiceTests
 
         var qs = new QuoteService(quotes, users);
 
-        Assert.AreEqual(new Quote(0, "Sunny", "gonna be my day"), qs.GetRandomQuote(testGuild));
-        Assert.AreEqual(new Quote(0, "Sunny", "gonna be my day"), qs.GetRandomQuote(sunny));
+        Assert.AreEqual((0, "gonna be my day"), qs.GetRandomQuote(sunny.Id));
 
         TestUtils.AssertListsAreEqual(new List<string> { "Sunny (Sunny#1234) " }, qs.GetKeyList(testGuild));
 
-        Assert.AreEqual(new Quote(0, "Sunny", "gonna be my day"), new Quote(0, "Sunny", "gonna be my day"));
-        Assert.AreEqual(new Quote(0, "Sunny", "gonna be my day"), qs.GetQuote(sunny, 0));
+        Assert.AreEqual("gonna be my day", qs.GetQuote(sunny.Id, 0));
 
         TestUtils.AssertListsAreEqual(new List<string> {
             "gonna be my day"

--- a/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
@@ -32,22 +32,22 @@ public class QuoteServiceTests
         Assert.AreEqual(new Quote(0, "Sunny", "gonna be my day"), new Quote(0, "Sunny", "gonna be my day"));
         Assert.AreEqual(new Quote(0, "Sunny", "gonna be my day"), qs.GetQuote(sunny, 0));
 
-        TestUtils.AssertListsAreEqual(new List<Quote> {
-            new Quote(0, "Sunny", "gonna be my day")
-        }, qs.GetQuotes(sunny));
+        TestUtils.AssertListsAreEqual(new List<string> {
+            "gonna be my day"
+        }, qs.GetQuotes(sunny.Id));
 
         await qs.AddQuote(sunny, "eat more vegetables");
 
-        TestUtils.AssertListsAreEqual(new List<Quote> {
-            new Quote(0, "Sunny", "gonna be my day"),
-            new Quote(1, "Sunny", "eat more vegetables")
-        }, qs.GetQuotes(sunny));
+        TestUtils.AssertListsAreEqual(new List<string> {
+            "gonna be my day",
+            "eat more vegetables"
+        }, qs.GetQuotes(sunny.Id));
 
         await qs.RemoveQuote(sunny, 0);
 
-        TestUtils.AssertListsAreEqual(new List<Quote> {
-            new Quote(0, "Sunny", "eat more vegetables")
-        }, qs.GetQuotes(sunny));
+        TestUtils.AssertListsAreEqual(new List<string> {
+            "eat more vegetables"
+        }, qs.GetQuotes(sunny.Id));
     }
 
     [TestMethod()]


### PR DESCRIPTION
Closes #57 

- clean up the whole "quote categories" thing; everyone seems happy with fake users and this makes the code a _lot_ simpler
- .q/.lq now return null instead of throw exceptions to deal with benign errors like a user having zero quotes, which provides better typings and makes it far less annoying to run these commands under a debugger
- .q/.lq's implementations now work with userIds instead of confusingly treating a non-member user as if they were a category
- .q/.lq now prefer to output @mentions over name#1234
- `.help <quotealias>` is now a thing
- a _lot_ of redundant code was deduplicated

There's always more that could be done (the add/remove/alias commands could be similarly modernized, we could remove the `Quote` type entirely, quote storage could be migrated to no longer stringify userIds, .help's other codepaths could search quotealiases for suggestions...), but this is good enough that I consider the issue of polishing quotes to be completed until we get asked to change stuff.