### PR TITLE
re-teach .q/.lq to get a displayname from userinfo for left users

### DIFF
--- a/Izzy-Moonbot/Modules/MiscModule.cs
+++ b/Izzy-Moonbot/Modules/MiscModule.cs
@@ -387,9 +387,9 @@ public class MiscModule : ModuleBase<SocketCommandContext>
         // Try quote aliases
         else if (_quoteService.AliasExists(item))
         {
-            var user = _quoteService.ProcessAlias(item, context.Guild);
+            var userId = _quoteService.ProcessAlias(item, context.Guild);
 
-            await context.Channel.SendMessageAsync($"'{item}' is a quotealias for the user <@{user.Id}>. Use `.listquotes {item}` or `.quote {item}` to see their quotes." +
+            await context.Channel.SendMessageAsync($"'{item}' is a quotealias for the user <@{userId}>. Use `.listquotes {item}` or `.quote {item}` to see their quotes." +
                 "\n\nSee `.help quote` and `.help quotelias` for more information.");
         }
         else

--- a/Izzy-Moonbot/Service/QuoteService.cs
+++ b/Izzy-Moonbot/Service/QuoteService.cs
@@ -33,31 +33,14 @@ public class QuoteService
         return _quoteStorage.Aliases.Keys.Any(key => key.ToLower() == alias.ToLower());
     }
 
-    /// <summary>
-    /// Process an alias into a IIzzyUser.
-    /// </summary>
-    /// <param name="alias">The alias to process.</param>
-    /// <param name="guild">The guild to get the user from.</param>
-    /// <returns>An instance of IIzzyUser that this alias refers to.</returns>
-    /// <exception cref="TargetException">If the user couldn't be found (left the server).</exception>
-    /// <exception cref="ArgumentException">If the alias doesn't refer to a user.</exception>
-    /// <exception cref="NullReferenceException">If the alias doesn't exist.</exception>
-    public IIzzyUser ProcessAlias(string alias, IIzzyGuild? guild)
+    public ulong ProcessAlias(string alias, IIzzyGuild? guild)
     {
         alias = alias.ToLower();
 
         if (!_quoteStorage.Aliases.TryGetValue(alias, out var value))
             throw new NullReferenceException("That alias does not exist.");
 
-        if (ulong.TryParse(value, out var id))
-        {
-            var potentialUser = guild?.GetUser(id);
-            if (potentialUser == null)
-                throw new TargetException("The user this alias referenced to cannot be found.");
-
-            return potentialUser;
-        }
-        throw new ArgumentException("This alias cannot be converted to an IIzzyUser.");
+        return ulong.Parse(value);
     }
 
     /// <summary>

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -21,7 +21,7 @@ public class QuoteModuleTests
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
-        var qm = new QuotesModule(cfg, qs);
+        var qm = new QuotesModule(cfg, qs, userinfo);
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote");
         await qm.TestableQuoteCommandAsync(context, "");
@@ -66,7 +66,7 @@ public class QuoteModuleTests
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
-        var qm = new QuotesModule(cfg, qs);
+        var qm = new QuotesModule(cfg, qs, userinfo);
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes");
         await qm.TestableListQuotesCommandAsync(context, "");
@@ -130,7 +130,7 @@ public class QuoteModuleTests
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
-        var qm = new QuotesModule(cfg, qs);
+        var qm = new QuotesModule(cfg, qs, userinfo);
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes");
         await qm.TestableListQuotesCommandAsync(context, "");
@@ -156,7 +156,7 @@ public class QuoteModuleTests
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
-        var qm = new QuotesModule(cfg, qs);
+        var qm = new QuotesModule(cfg, qs, userinfo);
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Sunny");
         await qm.TestableListQuotesCommandAsync(context, "Sunny");
@@ -184,7 +184,7 @@ public class QuoteModuleTests
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
-        var qm = new QuotesModule(cfg, qs);
+        var qm = new QuotesModule(cfg, qs, userinfo);
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote");
         await qm.TestableAddQuoteCommandAsync(context, "");


### PR DESCRIPTION
https://github.com/Manechat/izzy-moonbot/pull/382 had the unexpected regression that moon quotes no longer say "Messages on the Moon":
![image](https://github.com/Manechat/izzy-moonbot/assets/5285357/dcea513e-2c3b-4d54-9772-2cf979cae41a)

Unfortunately the relevant conditions are different in Bot Testing, so this is a bit of a guess fix, but I believe the only way Izzy could've ever displayed this name is by relying on `_users`/userinfo carrying it around long after Discord lost access to it, so here I'm making the reliance on ancient names far more explicit than it was before.

Supporting this theory, the userinfo backup I happen to have on my machine contains:
```json
  "421314201944981504": {
    "Username": "Messages on the Moon#0511",
```
and the code deleted in #382 contains multiple lines like this:
```cs
quoteName = _users.ContainsKey(userId) ? _users[userId].Username : $"<@{userId}>";
```