### PR TITLE
test if app command permissions work the way I think they do

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -211,10 +211,11 @@ namespace Izzy_Moonbot
             // var gacs = await _client.Rest.GetGuildApplicationCommands(guildId);
 
             var guildUserCommand = new UserCommandBuilder()
-                .WithName(".userinfo (ephemeral)");
+                .WithName(".userinfo (ephemeral)")
+                .WithDefaultPermission(false);
             var guildMessageCommand = new MessageCommandBuilder()
                 .WithName("Test Message Command")
-                .WithDefaultMemberPermissions(null);
+                .WithDefaultMemberPermissions(GuildPermission.Administrator);
             try
             {
                 await guild.BulkOverwriteApplicationCommandAsync(new ApplicationCommandProperties[]


### PR DESCRIPTION
`.WithDefaultMemberPermissions(null)` did not do what past me apparently expected it to, so before I put the effort into making these commands do something useful like `.permanp`, we need to be sure they won't show up for non-mods like my alt. I'm testing two different methods because the Discord.NET docs are kinda bad and don't explain what either of them actually mean.