### PR TITLE
apparently application command names have a max length of 32

### DIFF
--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -212,14 +212,15 @@ namespace Izzy_Moonbot
             // TODO: avoid resetting app commands if they're already set up
             // var gacs = await _client.Rest.GetGuildApplicationCommands(guildId);
 
+            // WARNING: command Names have a limit of 32 characters
             var userinfoCommand = new UserCommandBuilder()
-                .WithName(".userinfo (ephemeral response)")
+                .WithName(".userinfo (ephemeral)")
                 .WithDefaultMemberPermissions(GuildPermission.Administrator);
             var permanpCommand = new UserCommandBuilder()
-                .WithName(".permanp (response in ModChannel)")
+                .WithName(".permanp (in ModChannel)")
                 .WithDefaultMemberPermissions(GuildPermission.Administrator);
             var addquoteCommand = new MessageCommandBuilder()
-                .WithName(".addquote (response in this channel)")
+                .WithName(".addquote (in this channel)")
                 .WithDefaultMemberPermissions(GuildPermission.Administrator);
             try
             {
@@ -253,13 +254,13 @@ namespace Izzy_Moonbot
                 return;
             }
 
-            if (command.CommandName == ".userinfo (ephemeral response)")
+            if (command.CommandName == ".userinfo (ephemeral)")
             {
                 var output = await ModCoreModule.UserInfoImpl(_client, (ulong)guildId, command.Data.Member.Id, _users);
 
                 await command.RespondAsync($"Executed '{command.CommandName}' and got:\n\n{output}", ephemeral: true);
             }
-            else if (command.CommandName == ".permanp (response in ModChannel)")
+            else if (command.CommandName == ".permanp (in ModChannel)")
             {
                 var output = await ModMiscModule.PermaNpCommandIImpl(_scheduleService, _config, command.Data.Member.Id);
 


### PR DESCRIPTION
```
[2023-05-10 23:55:11 ERR] Izzy Moonbot has encountered an error. Logging information...
[2023-05-10 23:55:11 ERR] Message: Value must be at most 32. (Parameter 'Name')
[2023-05-10 23:55:11 ERR] Source: Discord.Net.Core
[2023-05-10 23:55:11 ERR] HResult: -2147024809
[2023-05-10 23:55:11 ERR] Stack trace:    at Discord.Preconditions.AtMost(Int32 obj, Int32 value, String name, String msg)
   at Discord.UserCommandBuilder.set_Name(String value)
   at Discord.UserCommandBuilder.WithName(String name)
   at Izzy_Moonbot.Worker.ReadyEvent() in /src/Izzy-Moonbot/Worker.cs:line 218
   at Discord.EventExtensions.InvokeAsync(AsyncEvent`1 eventHandler)
   at Discord.WebSocket.DiscordSocketClient.TimeoutWrap(String name, Func`1 action)
[2023-05-10 23:55:11 INF] A Ready handler has thrown an unhandled exception.
[2023-05-10 23:55:11 INF] Ready
[2023-05-10 23:55:12 INF] Resynce
```