### PR TITLE
Change quote module formatting, lookup names for left users

### DIFF
--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -200,7 +200,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             $"Here's all the quotes I have for **{await DisplayUserName(userId, context.Client, defaultGuild)}**:\n",
             quotes.Select((quote, index) => $"{index + 1}. {quote}").Select(SanitizeQuote).ToArray(),
             $"\nRun `{_config.Prefix}quote <user> <number>` to get a specific quote.\n" +
-            $"Run `{_config.Prefix}quote <user>` to get a random quote from that user." +
+            $"Run `{_config.Prefix}quote <user>` to get a random quote from that user.\n" +
             $"Run `{_config.Prefix}quote` for a random quote from a random user.",
             codeblock: false,
             pageSize: 15,

--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -7,7 +7,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
-using Discord.WebSocket;
 using Izzy_Moonbot.Adapters;
 using Izzy_Moonbot.Attributes;
 using Izzy_Moonbot.Helpers;
@@ -283,15 +282,16 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
         await context.Channel.SendMessageAsync(output, allowedMentions: AllowedMentions.None);
     }
 
-    static public async Task<string> AddQuoteCommandImpl(QuoteService quoteService, IIzzyGuild guild, ulong userId, string content)
+    public static async Task<string> AddQuoteCommandImpl(QuoteService quoteService, IIzzyGuild guild, ulong userId, string content)
     {
         var member = guild.GetUser(userId);
+
         if (member == null)
             return "I was unable to find the user you asked for. Sorry!";
 
         var newQuote = await quoteService.AddQuote(member, content);
 
-        return $"Added the quote to <@{userId}> as quote number {newQuote.Id + 1}.\n" +
+        return $"Added quote #{newQuote.Id + 1} to **{member.DisplayName}**:\n\n" +
             $">>> {SanitizeQuote(newQuote.Content)}";
     }
 
@@ -353,7 +353,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             await _quoteService.RemoveQuote(quoteUser, number.Value - 1);
 
             await context.Channel.SendMessageAsync(
-                $"Removed quote number {number.Value} from **{quoteUser.Username}#{quoteUser.Discriminator}**.", allowedMentions: AllowedMentions.None);
+                $"Removed quote #{number.Value} from **{quoteUser.Username}#{quoteUser.Discriminator}**.", allowedMentions: AllowedMentions.None);
             return;
         }
 
@@ -370,7 +370,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
         var newUserQuote = await _quoteService.RemoveQuote(member, number.Value - 1);
 
         await context.Channel.SendMessageAsync(
-            $"Removed quote number {number.Value} from **{newUserQuote.Name}**.", allowedMentions: AllowedMentions.None);
+            $"Removed quote #{number.Value} from **{newUserQuote.Name}**.", allowedMentions: AllowedMentions.None);
         return;
     }
 

--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -199,12 +199,9 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             context,
             $"Here's all the quotes I have for **{await DisplayUserName(userId, context.Client, defaultGuild)}**:\n",
             quotes.Select((quote, index) => $"{index + 1}. {quote}").Select(SanitizeQuote).ToArray(),
-            $"""
-
-            Run `{_config.Prefix}quote <user> <number>` to get a specific quote.
-            Run `{_config.Prefix}quote <user>` to get a random quote from that user.
-            Run `{_config.Prefix}quote` for a random quote from a random user.
-            """,
+            $"\nRun `{_config.Prefix}quote <user> <number>` to get a specific quote.\n" +
+            $"Run `{_config.Prefix}quote <user>` to get a random quote from that user." +
+            $"Run `{_config.Prefix}quote` for a random quote from a random user.",
             codeblock: false,
             pageSize: 15,
             allowedMentions: AllowedMentions.None

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -12,6 +12,8 @@ public class QuoteModuleTests
     [TestMethod()]
     public async Task QuoteCommand_Tests()
     {
+        // setup
+
         var (cfg, _, (_, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();
         DiscordHelper.DefaultGuildId = guild.Id;
 
@@ -23,104 +25,156 @@ public class QuoteModuleTests
         var qs = new QuoteService(quotes, userinfo);
         var qm = new QuotesModule(cfg, qs, userinfo);
 
+        // setup end
+
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote");
         await qm.TestableQuoteCommandAsync(context, "");
-        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+
+        //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote Sunny");
         await qm.TestableQuoteCommandAsync(context, "Sunny");
-        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+
+        //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}>");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}>");
-        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+
+        //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}> 1");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}> 1");
-        Assert.AreEqual($"<@{sunny.Id}> **`#1`:** gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+
+        //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}> 2");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}> 2");
         Assert.AreEqual("I couldn't find that quote, sorry!", generalChannel.Messages.Last().Content);
+
+        //
 
         // Zipp has no quotes because she never appeared on the pippcast
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote Zipp");
         await qm.TestableQuoteCommandAsync(context, "Zipp");
         Assert.AreEqual("I couldn't find any quotes for that user.", generalChannel.Messages.Last().Content);
 
+        //
+
         // Twi didn't make it to G5
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote Twilight");
         await qm.TestableQuoteCommandAsync(context, "Twilight");
         Assert.AreEqual("I was unable to find the user you asked for. Sorry!", generalChannel.Messages.Last().Content);
+
+        // TODO: test cases where user left (both cached in userinfo and not)
     }
 
     [TestMethod()]
     public async Task ListQuotes_Tests()
     {
+        // setup
+
         var (cfg, _, (izzy, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();
+        var pipp = guild.Users[3];
         DiscordHelper.DefaultGuildId = guild.Id;
 
         var quotes = new QuoteStorage();
         quotes.Quotes.Add(sunny.Id.ToString(), new List<string> { "gonna be my day", "eat more vegetables" });
         quotes.Quotes.Add(izzy.Id.ToString(), new List<string> { "let's unicycle it" });
+        quotes.Quotes.Add(pipp.Id.ToString(), new List<string> {
+            "Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!",
+            "It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! https://youtu.be/CLT4aSurqCg"
+         });
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
         var qm = new QuotesModule(cfg, qs, userinfo);
+
+        // setup end
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes");
         await qm.TestableListQuotesCommandAsync(context, "");
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Here's all the");
-        StringAssert.Contains(description, $"```\n" +
-            $"Sunny (Sunny#1234) \n" +
-            $"Izzy Moonbot (Izzy Moonbot#1234) \n" +
-            $"```\n");
+        StringAssert.Contains(description, "```\n" +
+            "Sunny (Sunny#1234) \n" +
+            "Izzy Moonbot (Izzy Moonbot#1234) \n" +
+            "Pipp (Pipp#1234) \n" +
+            "```\n");
         StringAssert.Contains(description, "Run `.quote <user>`");
         StringAssert.Contains(description, "Run `.quote`");
+
+        //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Izzy");
         await qm.TestableListQuotesCommandAsync(context, "Izzy");
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, $"for <@{izzy.Id}>");
-        StringAssert.Contains(description, $"```\n" +
-            $"1: let's unicycle it\n" +
-            $"```\n");
+        StringAssert.Contains(description, $"for **{izzy.DisplayName}**:");
+        StringAssert.Contains(description, "\n\n" +
+            $"1. let's unicycle it\n" +
+            "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");
         StringAssert.Contains(description, "Run `.quote` for");
+
+        //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Sunny");
         await qm.TestableListQuotesCommandAsync(context, "Sunny");
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, $"for <@{sunny.Id}>");
-        StringAssert.Contains(description, $"```\n" +
-            $"1: gonna be my day\n" +
-            $"2: eat more vegetables\n" +
-            $"```\n");
+        StringAssert.Contains(description, $"for **{sunny.DisplayName}**:");
+        StringAssert.Contains(description, "\n\n" +
+            "1. gonna be my day\n" +
+            "2. eat more vegetables\n" +
+            "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");
         StringAssert.Contains(description, "Run `.quote` for");
+
+        //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Zipp");
         await qm.TestableListQuotesCommandAsync(context, "Zipp");
 
         Assert.AreEqual("I couldn't find any quotes for that user.", generalChannel.Messages.Last().Content);
 
+        //
+
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Twilight");
         await qm.TestableListQuotesCommandAsync(context, "Twilight");
 
         Assert.AreEqual("I was unable to find the user you asked for. Sorry!", generalChannel.Messages.Last().Content);
+
+        //
+
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Pipp");
+        await qm.TestableListQuotesCommandAsync(context, "Pipp");
+
+        description = generalChannel.Messages.Last().Content;
+        StringAssert.Contains(description, "all the quotes");
+        StringAssert.Contains(description, $"for **{pipp.DisplayName}**:");
+        StringAssert.Contains(description, "\n\n" +
+            "1. Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!\n" +
+            "2. It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! <https://youtu.be/CLT4aSurqCg>\n" +
+            "\n");
+        StringAssert.Contains(description, "Run `.quote <user> <number>` to");
+        StringAssert.Contains(description, "Run `.quote <user>` to");
+        StringAssert.Contains(description, "Run `.quote` for");
     }
 
     [TestMethod()]
     public async Task ListQuotes_ExternalUsers_Tests()
     {
+        // setup
+
         var (cfg, _, (izzy, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();
         DiscordHelper.DefaultGuildId = guild.Id;
 
@@ -132,14 +186,16 @@ public class QuoteModuleTests
         var qs = new QuoteService(quotes, userinfo);
         var qm = new QuotesModule(cfg, qs, userinfo);
 
+        // setup end
+
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes");
         await qm.TestableListQuotesCommandAsync(context, "");
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Here's all the");
-        StringAssert.Contains(description, $"```\n" +
-            $"1234 \n" +
-            $"```\n");
+        StringAssert.Contains(description, "```\n" +
+            "1234 \n" +
+            "```\n");
         StringAssert.Contains(description, "Run `.quote <user>`");
         StringAssert.Contains(description, "Run `.quote`");
     }
@@ -148,6 +204,8 @@ public class QuoteModuleTests
     [TestMethod()]
     public async Task ListQuotes_Duplicates_Tests()
     {
+        // setup
+
         var (cfg, _, (izzy, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();
         DiscordHelper.DefaultGuildId = guild.Id;
 
@@ -158,16 +216,18 @@ public class QuoteModuleTests
         var qs = new QuoteService(quotes, userinfo);
         var qm = new QuotesModule(cfg, qs, userinfo);
 
+        // setup end
+
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".listquotes Sunny");
         await qm.TestableListQuotesCommandAsync(context, "Sunny");
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, $"for <@{sunny.Id}>");
-        StringAssert.Contains(description, $"```\n" +
-            $"1: gonna be my day\n" +
-            $"2: gonna be my day\n" +
-            $"```\n");
+        StringAssert.Contains(description, $"for **{sunny.DisplayName}**:");
+        StringAssert.Contains(description, "\n\n" +
+            "1. gonna be my day\n" +
+            "2. gonna be my day\n" +
+            "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");
         StringAssert.Contains(description, "Run `.quote` for");
@@ -176,7 +236,10 @@ public class QuoteModuleTests
     [TestMethod()]
     public async Task AddAndRemoveQuotes_Tests()
     {
+        // setup
+
         var (cfg, _, (_, sunny), _, (generalChannel, _, _), guild, client) = TestUtils.DefaultStubs();
+        var pipp = guild.Users[3];
         DiscordHelper.DefaultGuildId = guild.Id;
 
         var quotes = new QuoteStorage();
@@ -186,33 +249,64 @@ public class QuoteModuleTests
         var qs = new QuoteService(quotes, userinfo);
         var qm = new QuotesModule(cfg, qs, userinfo);
 
+        // setup end
+
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote");
         await qm.TestableAddQuoteCommandAsync(context, "");
+
         Assert.AreEqual("You need to tell me the user you want to add the quote to, and the content of the quote.", generalChannel.Messages.Last().Content);
         TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
             "gonna be my day"
         });
 
+        //
+
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote Sunny eat more vegetables");
         await qm.TestableAddQuoteCommandAsync(context, "Sunny eat more vegetables");
-        Assert.AreEqual($"Added the quote to <@{sunny.Id}> as quote number 2." +
-            $"\n>>> eat more vegetables", generalChannel.Messages.Last().Content);
+
+        Assert.AreEqual($"Added quote #2 to **{sunny.DisplayName}**:\n" +
+            "\n" +
+            ">>> eat more vegetables", generalChannel.Messages.Last().Content);
         TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
             "gonna be my day",
             "eat more vegetables"
         });
 
+        //
+
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote Pipp Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!");
+        await qm.TestableAddQuoteCommandAsync(context, "Pipp Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!");
+
+        Assert.AreEqual($"Added quote #1 to **{pipp.DisplayName}**:\n" +
+            "\n" +
+            ">>> Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!", generalChannel.Messages.Last().Content);
+
+        //
+
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! https://youtu.be/CLT4aSurqCg");
+        await qm.TestableAddQuoteCommandAsync(context, "Pipp It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! https://youtu.be/CLT4aSurqCg");
+
+        Assert.AreEqual($"Added quote #2 to **{pipp.DisplayName}**:\n" +
+            "\n" +
+            ">>> It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! <https://youtu.be/CLT4aSurqCg>", generalChannel.Messages.Last().Content);
+
+        //
+
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".removequote");
         await qm.TestableRemoveQuoteCommandAsync(context, "");
+
         Assert.AreEqual("You need to tell me the user you want to remove the quote from, and the quote number to remove.", generalChannel.Messages.Last().Content);
         TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
             "gonna be my day",
             "eat more vegetables"
         });
 
+        //
+
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".removequote <@{sunny.Id}> 1");
         await qm.TestableRemoveQuoteCommandAsync(context, $"<@{sunny.Id}> 1");
-        Assert.AreEqual("Removed quote number 1 from **Sunny**.", generalChannel.Messages.Last().Content);
+
+        Assert.AreEqual($"Removed quote #1 from **{sunny.DisplayName}**.", generalChannel.Messages.Last().Content);
         TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
             "eat more vegetables"
         });


### PR DESCRIPTION
Previously quotes used pingless mentions to display user names, but that resulted in them sometimes not getting resolved and looking ugly. It would also happen if a user left the server before izzy could cache them. Now izzy manually resolves the user's nick/name and posts it in plaintext.

![image](https://github.com/Manechat/izzy-moonbot/assets/19710443/e81c5580-278d-449e-8259-f69b331efa83)


I also found the quote list to be ugly because of the codeblock so I removed that and added some empty lines to make it look cleaner. In addition, quotes that have any kind of formatting (i.e. bold, italics, etc.) now display properly.

![image](https://github.com/Manechat/izzy-moonbot/assets/19710443/c16598d5-f8a6-44e3-a03c-1b381cf71100)
