### PR TITLE
introduce a singular GetArgument() method to build other argument parse helpers atop

### DIFF
--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -141,10 +141,9 @@ public static class DiscordHelper
     {
         Func<string, string> trimQuotes = arg =>
         {
-            if (arg[0] == '"' && arg.Last() == '"')
-                return arg[1..(arg.Length - 1)];
-            else
-                return arg;
+            return (arg[0] == '"' && arg.Last() == '"') ?
+                arg[1..(arg.Length - 1)] :
+                arg;
         };
 
         var betweenQuotes = false;
@@ -152,11 +151,10 @@ public static class DiscordHelper
         {
             var c = args[i];
 
-            // start or end a quoted argument
-            if (c == '"')
-                // only if that quote is unescaped (and \ only has this special meaning when preceding ")
-                if (i <= 1 || args[i-1] != '\\')
-                    betweenQuotes = !betweenQuotes;
+            // start or end a quoted argument only if that quote is unescaped
+            // (and \ only has this special meaning when preceding ")
+            if ((c == '"') && (i <= 1 || args[i-1] != '\\'))
+                betweenQuotes = !betweenQuotes;
 
             // found a space outside quotes; that means we've reached the end of the current arg
             if (IsSpace(c) && !betweenQuotes)
@@ -169,25 +167,22 @@ public static class DiscordHelper
 
                 // If there are only spaces after the arg, then it's the last arg if any
                 if (endOfSpaceRun >= args.Length)
-                    if (nextArg == "")
-                        return (null, null);
-                    else
-                        return (trimQuotes(nextArg), null);
+                    return (nextArg == "") ?
+                        (null, null) :
+                        (trimQuotes(nextArg), null);
                 // otherwise there are more args left to parse with future GetArgument() calls
                 else
-                    if (nextArg == "")
-                        // this "arg" was the empty string, recurse so caller gets the first non-empty arg if any
-                        return GetArgument(args.Substring(endOfSpaceRun));
-                    else
-                        return (trimQuotes(nextArg), args.Substring(endOfSpaceRun));
+                    return (nextArg == "") ?
+                        // if this "arg" was the empty string, recurse so caller gets the first non-empty arg if any
+                        GetArgument(args.Substring(endOfSpaceRun)) :
+                        (trimQuotes(nextArg), args.Substring(endOfSpaceRun));
             }
         }
 
         // If we never found a space (outside a quoted arg), then the whole string is at most one arg
-        if (args == "")
-            return (null, null);
-        else
-            return (trimQuotes(args), null);
+        return (args == "") ?
+            (null, null) :
+            (trimQuotes(args), null);
     }
 
     public static ArgumentResult GetArguments(string content)

--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -135,60 +135,88 @@ public static class DiscordHelper
         return array.ElementAt(index);
     }
 
+    // The return value is (nextArgString, remainingArgsIfAny)
+    // string.Split() does not suffice because we want to support quoted arguments
+    public static (string?, string?) GetArgument(string args)
+    {
+        Func<string, string> trimQuotes = arg =>
+        {
+            if (arg[0] == '"' && arg.Last() == '"')
+                return arg[1..(arg.Length - 1)];
+            else
+                return arg;
+        };
+
+        var betweenQuotes = false;
+        for (var i = 0; i < args.Length; i++)
+        {
+            var c = args[i];
+
+            // start or end a quoted argument
+            if (c == '"')
+                // only if that quote is unescaped (and \ only has this special meaning when preceding ")
+                if (i <= 1 || args[i-1] != '\\')
+                    betweenQuotes = !betweenQuotes;
+
+            // found a space outside quotes; that means we've reached the end of the current arg
+            if (IsSpace(c) && !betweenQuotes)
+            {
+                var nextArg = args.Substring(0, i);
+
+                var endOfSpaceRun = i;
+                while (endOfSpaceRun < args.Length && IsSpace(args[endOfSpaceRun]))
+                    endOfSpaceRun++;
+
+                // If there are only spaces after the arg, then it's the last arg if any
+                if (endOfSpaceRun >= args.Length)
+                    if (nextArg == "")
+                        return (null, null);
+                    else
+                        return (trimQuotes(nextArg), null);
+                // otherwise there are more args left to parse with future GetArgument() calls
+                else
+                    if (nextArg == "")
+                        // this "arg" was the empty string, recurse so caller gets the first non-empty arg if any
+                        return GetArgument(args.Substring(endOfSpaceRun));
+                    else
+                        return (trimQuotes(nextArg), args.Substring(endOfSpaceRun));
+            }
+        }
+
+        // If we never found a space (outside a quoted arg), then the whole string is at most one arg
+        if (args == "")
+            return (null, null);
+        else
+            return (trimQuotes(args), null);
+    }
+
     public static ArgumentResult GetArguments(string content)
     {
-        var characters = content.ToCharArray();
-        
         var arguments = new List<string>();
         var indices = new List<int>();
 
-        for (var i = 0; i < characters.Length; i++)
+        var (nextArg, remainingArgs) = GetArgument(content);
+        if (nextArg != null)
         {
-            var argument = characters[i];
-            if (!IsSpace(argument))
+            arguments.Add(nextArg);
+            if (remainingArgs != null)
+                indices.Add(content.Length - remainingArgs.Length);
+            else
+                indices.Add(content.Length);
+
+            while (remainingArgs != null)
             {
-                var safePrevious = (char?)GetSafely(characters, i - 1);
-                
-                if (argument == '"' && (i < 1 || safePrevious != '\\'))
+                var remainingLength = remainingArgs!.Length;
+
+                (nextArg, remainingArgs) = GetArgument(remainingArgs);
+                if (nextArg != null)
                 {
-                    i++;
-                    var start = i;
-
-                    while (i < content.Length && (characters[i] != '"' || characters[i-1] == '\\'))
-                    {
-                        i++;
-                    }
-
-                    int end;
-                    if (i-1 >= 0 && characters[i-1] == '\\')
-                    {
-                        end = i - 1;
-                    }
+                    arguments.Add(nextArg);
+                    if (remainingArgs != null)
+                        indices.Add(indices.Last() + (remainingLength - remainingArgs.Length));
                     else
-                    {
-                        end = i;
-                        i++;
-                    }
-                    arguments.Add(string.Join("", content[new Range(start, end)]));
+                        indices.Add(content.Length);
                 }
-                else
-                {
-                    var start = i;
-                    i++;
-                    
-                    while (i < content.Length && !IsSpace(characters[i]) &&
-                           (characters[i] != '"' || characters[i-1] == '\\'))
-                    {
-                        i++;
-                    }
-                    arguments.Add(string.Join("", content[new Range(start, i)]));
-                }
-
-                var nextIndex = i;
-                while (nextIndex < characters.Length && IsSpace(characters[nextIndex]))
-                    nextIndex++;
-
-                indices.Add(nextIndex);
             }
         }
 

--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -165,14 +165,13 @@ public static class DiscordHelper
                 while (endOfSpaceRun < args.Length && IsSpace(args[endOfSpaceRun]))
                     endOfSpaceRun++;
 
-                // If there are only spaces after the arg, then it's the last arg if any
-                if (endOfSpaceRun >= args.Length)
-                    return (nextArg == "") ?
+                return (endOfSpaceRun >= args.Length) ?
+                    // If there are only spaces after the arg, then it's the last arg if any
+                    (nextArg == "") ?
                         (null, null) :
-                        (trimQuotes(nextArg), null);
-                // otherwise there are more args left to parse with future GetArgument() calls
-                else
-                    return (nextArg == "") ?
+                        (trimQuotes(nextArg), null) :
+                    // otherwise there are more args left to parse with future GetArgument() calls
+                    (nextArg == "") ?
                         // if this "arg" was the empty string, recurse so caller gets the first non-empty arg if any
                         GetArgument(args.Substring(endOfSpaceRun)) :
                         (trimQuotes(nextArg), args.Substring(endOfSpaceRun));

--- a/Izzy-MoonbotTests/Tests/DiscordHelperTests.cs
+++ b/Izzy-MoonbotTests/Tests/DiscordHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using Izzy_Moonbot.Helpers;
+using Izzy_Moonbot.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Izzy_Moonbot.Helpers.DiscordHelper;
 
@@ -58,143 +58,114 @@ public class DiscordHelperTests
         Assert.ThrowsException<FormatException>(() => DiscordHelper.ConvertRolePingToId("foo <@&1234> bar"));
     }
 
-    void AssertArgumentResultsAreEqual(ArgumentResult expected, ArgumentResult actual)
+    [TestMethod()]
+    public void GetArgument_NoQuotesTests()
     {
-        TestUtils.AssertListsAreEqual(expected.Arguments, actual.Arguments, "\nArguments");
-        TestUtils.AssertListsAreEqual(expected.Indices, actual.Indices, "\nIndices");
-    }
+        Assert.AreEqual((null, null), DiscordHelper.GetArgument(""));
 
-    string SkippedArgsString(string argsString, int argsToSkip)
-    {
-        var args = DiscordHelper.GetArguments(argsString);
-        return string.Join("", argsString.Skip(args.Indices[argsToSkip]));
+        Assert.AreEqual((null, null), DiscordHelper.GetArgument(" "));
+
+        Assert.AreEqual(("foo", null), DiscordHelper.GetArgument("foo"));
+
+        Assert.AreEqual(("foo", null), DiscordHelper.GetArgument("foo "));
+
+        Assert.AreEqual(("foo", null), DiscordHelper.GetArgument(" foo"));
+
+        Assert.AreEqual(("foo", "bar"), DiscordHelper.GetArgument("foo bar"));
+        Assert.AreEqual(("bar", null), DiscordHelper.GetArgument("bar"));
+
+        Assert.AreEqual(("foo", "bar"), DiscordHelper.GetArgument("foo    bar"));
+        Assert.AreEqual(("bar", null), DiscordHelper.GetArgument("bar"));
+
+        Assert.AreEqual(("foo", "bar   "), DiscordHelper.GetArgument("foo bar   "));
+        Assert.AreEqual(("bar", null), DiscordHelper.GetArgument("bar   "));
+
+        Assert.AreEqual(("foo", "bar"), DiscordHelper.GetArgument("   foo bar"));
+        Assert.AreEqual(("bar", null), DiscordHelper.GetArgument("bar"));
+
+        Assert.AreEqual(("foo", "baaaar"), DiscordHelper.GetArgument("foo baaaar"));
+        Assert.AreEqual(("baaaar", null), DiscordHelper.GetArgument("baaaar"));
+
+        Assert.AreEqual(("foo", "bar baz"), DiscordHelper.GetArgument("foo bar baz"));
+        Assert.AreEqual(("bar", "baz"), DiscordHelper.GetArgument("bar baz"));
+        Assert.AreEqual(("baz", null), DiscordHelper.GetArgument("baz"));
+
+        Assert.AreEqual(("foo", "bar   baz"), DiscordHelper.GetArgument("foo   bar   baz"));
+        Assert.AreEqual(("bar", "baz"), DiscordHelper.GetArgument("bar   baz"));
+        Assert.AreEqual(("baz", null), DiscordHelper.GetArgument("baz"));
+
+        Assert.AreEqual(("foo", "bar   baz   "), DiscordHelper.GetArgument("   foo   bar   baz   "));
+        Assert.AreEqual(("bar", "baz   "), DiscordHelper.GetArgument("bar   baz   "));
+        Assert.AreEqual(("baz", null), DiscordHelper.GetArgument("baz   "));
     }
 
     [TestMethod()]
-    public void GetArguments_NoQuotesTests()
+    public void GetArgument_QuotesTests()
     {
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = Array.Empty<string>(), Indices = Array.Empty<int>() }, DiscordHelper.GetArguments(""));
+        Assert.AreEqual(("", null), DiscordHelper.GetArgument("\"\""));
 
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = Array.Empty<string>(), Indices = Array.Empty<int>() }, DiscordHelper.GetArguments(" "));
+        Assert.AreEqual(("foo", null), DiscordHelper.GetArgument("\"foo\""));
 
-        var argsString = "foo";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo" }, Indices = new[] { 3 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
+        Assert.AreEqual(("foo bar", null), DiscordHelper.GetArgument("\"foo bar\""));
 
-        argsString = "foo ";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo" }, Indices = new[] { 4 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
+        Assert.AreEqual(("foo", "\"bar\""), DiscordHelper.GetArgument("foo \"bar\""));
+        Assert.AreEqual(("bar", null), DiscordHelper.GetArgument("\"bar\""));
 
-        argsString = " foo";
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "foo" }, Indices = new[] { 4 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
-
-        argsString = "foo bar";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "bar" }, Indices = new[] { 4, 7 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("bar", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("", SkippedArgsString(argsString, 1));
-
-        argsString = "foo    bar";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "bar" }, Indices = new[] { 7, 10 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("bar", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("", SkippedArgsString(argsString, 1));
-
-        argsString = "foo bar   ";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "bar" }, Indices = new[] { 4, 10 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("bar   ", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("", SkippedArgsString(argsString, 1));
-
-        argsString = "   foo bar";
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "foo", "bar" }, Indices = new[] { 7, 10 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("bar", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("", SkippedArgsString(argsString, 1));
-
-        argsString = "foo baaaar";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "baaaar" }, Indices = new[] { 4, 10 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("baaaar", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("", SkippedArgsString(argsString, 1));
-
-        argsString = "foo bar baz";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "bar", "baz" }, Indices = new[] { 4, 8, 11 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("bar baz", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("baz", SkippedArgsString(argsString, 1));
-        Assert.AreEqual("", SkippedArgsString(argsString, 2));
-
-        argsString = "foo   bar   baz";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "bar", "baz" }, Indices = new[] { 6, 12, 15 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("bar   baz", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("baz", SkippedArgsString(argsString, 1));
-        Assert.AreEqual("", SkippedArgsString(argsString, 2));
-
-        argsString = "   foo   bar   baz   ";
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "foo", "bar", "baz" }, Indices = new[] { 9, 15, 21 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("bar   baz   ", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("baz   ", SkippedArgsString(argsString, 1));
-        Assert.AreEqual("", SkippedArgsString(argsString, 2));
+        Assert.AreEqual(("foo", "\"bar baz\" quux"), DiscordHelper.GetArgument("foo \"bar baz\" quux"));
+        Assert.AreEqual(("bar baz", "quux"), DiscordHelper.GetArgument("\"bar baz\" quux"));
+        Assert.AreEqual(("quux", null), DiscordHelper.GetArgument("quux"));
     }
 
     [TestMethod()]
-    public void GetArguments_QuotesTests()
+    public void GetArgument_EscapedQuotesTests()
     {
-        var argsString = "\"\"";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "" }, Indices = new[] { 2 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
-
-        argsString = "\"foo\"";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo" }, Indices = new[] { 5 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
-
-        argsString = "\"foo bar\"";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo bar" }, Indices = new[] { 9 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
-
-        argsString = "foo \"bar\"";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "bar" }, Indices = new[] { 4, 9 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("\"bar\"", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("", SkippedArgsString(argsString, 1));
-
-        argsString = "foo \"bar baz\" quux";
-        AssertArgumentResultsAreEqual(new ArgumentResult{ Arguments = new[] { "foo", "bar baz", "quux" }, Indices = new[] { 4, 14, 18 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("\"bar baz\" quux", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("quux", SkippedArgsString(argsString, 1));
-        Assert.AreEqual("", SkippedArgsString(argsString, 2));
-    }
-
-    [TestMethod()]
-    public void GetArguments_EscapedQuotesTests()
-    {
-        var argsString = """
+        var parse = DiscordHelper.GetArgument("""
             "\""
-            """;
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "\\\"" }, Indices = new[] { 4 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
+            """);
+        Assert.AreEqual(("""
+            \"
+            """, null), parse);
 
-        argsString = """
+        parse = DiscordHelper.GetArgument("""
             "foo\"bar"
-            """;
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "foo\\\"bar" }, Indices = new[] { 10 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
+            """);
+        Assert.AreEqual(("""
+            foo\"bar
+            """, null), parse);
 
-        argsString = """
+        parse = DiscordHelper.GetArgument("""
             "fo\"o b\"ar"
-            """;
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "fo\\\"o b\\\"ar" }, Indices = new[] { 13 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("", SkippedArgsString(argsString, 0));
+            """);
+        Assert.AreEqual(("""
+            fo\"o b\"ar
+            """, null), parse);
 
-        argsString = """
+        parse = DiscordHelper.GetArgument("""
             foo\" "bar"
-            """;
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "foo\\\"", "bar" }, Indices = new[] { 6, 11 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("\"bar\"", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("", SkippedArgsString(argsString, 1));
+            """);
+        Assert.AreEqual(("""
+            foo\"
+            """, """
+            "bar"
+            """), parse);
+        parse = DiscordHelper.GetArgument("""
+            "bar"
+            """);
+        Assert.AreEqual(("bar", null), parse);
 
-        argsString = """
+        parse = DiscordHelper.GetArgument("""
             foo "bar baz\"" quux
-            """;
-        AssertArgumentResultsAreEqual(new ArgumentResult { Arguments = new[] { "foo", "bar baz\\\"", "quux" }, Indices = new[] { 4, 16, 20 } }, DiscordHelper.GetArguments(argsString));
-        Assert.AreEqual("\"bar baz\\\"\" quux", SkippedArgsString(argsString, 0));
-        Assert.AreEqual("quux", SkippedArgsString(argsString, 1));
-        Assert.AreEqual("", SkippedArgsString(argsString, 2));
+            """);
+        Assert.AreEqual(("foo", """
+            "bar baz\"" quux
+            """), parse);
+        parse = DiscordHelper.GetArgument("""
+            "bar baz\"" quux
+            """);
+        Assert.AreEqual(("""
+            bar baz\"
+            """, "quux"), parse);
+        Assert.AreEqual(("quux", null), DiscordHelper.GetArgument("quux"));
     }
 
     [TestMethod()]


### PR DESCRIPTION
Part of #293.

Although not strictly necessary, it's always annoyed me that the foundation of our argument parsing logic is a plural GetArgument**s**() method that tokenizes the entire argument string in one go, and then instead of providing actual tokens it returns indices into the original argument string. This is both more and less than callers really want, since they not only have to do this clunky `string.Join("", argsString.Skip(args.Indices[0]))` thing to get the actual first argument token, but they often have to repeatedly reparse parts of the string after applying their own logic to the early tokens, and they can't easily share the error handling logic for cases that affect nearly every command.

Thus, this PR reimplements GetArgument**s**() as a series of calls to a new singular GetArgument() that returns a nullable token and a nullable remaining args string. For now, I've only migrated GetArgument**s**() and TryParseDateTime() to it, partly because that's where I ran out of steam but also because it's not worth migrating each individual command until I've written more helper methods like TryParseUser() that cover the more interesting arg parsing logic that's both widely duplicated today and less thorough than we'd like.