### PR TITLE
clearer kick/ban message

### DIFF
--- a/Izzy-Moonbot/EventListeners/UserListener.cs
+++ b/Izzy-Moonbot/EventListeners/UserListener.cs
@@ -222,10 +222,10 @@ public class UserListener
         var output = $"Leave: {user.Username}#{user.Discriminator} ({lastNickname}) (`{user.Id}`) joined <t:{_users[user.Id].Joins.Last().ToUnixTimeSeconds()}:R>";
 
         if (banAuditLog != null)
-            output += $"\n\nAccording to the server audit log, they were **banned** at {banAuditLog.CreatedAt} by {banAuditLog.User.Username}#{banAuditLog.User.Discriminator} ({guild.GetUser((ulong)banAuditLog.User.Id).DisplayName}) for the following reason:\n\"{banAuditLog.Reason}\"";
+            output += $"\n\nAccording to the server audit log, they were **banned** at {banAuditLog.CreatedAt} by {banAuditLog.User.Username}#{banAuditLog.User.Discriminator} ({guild.GetUser(banAuditLog.User.Id).DisplayName}) for the following reason:\n\"{banAuditLog.Reason}\"";
 
         if (kickAuditLog != null)
-            output += $"\n\nAccording to the server audit log, they were **kicked** at {kickAuditLog.CreatedAt} by {kickAuditLog.User.Username}#{kickAuditLog.User.Discriminator} ({guild.GetUser((ulong)kickAuditLog.User.Id).DisplayName}) for the following reason:\n\"{kickAuditLog.Reason}\"";
+            output += $"\n\nAccording to the server audit log, they were **kicked** at {kickAuditLog.CreatedAt} by {kickAuditLog.User.Username}#{kickAuditLog.User.Discriminator} ({guild.GetUser(kickAuditLog.User.Id).DisplayName}) for the following reason:\n\"{kickAuditLog.Reason}\"";
 
         // Scheduled jobs that require a user to be in the server create a difficult question.
         // Do we delete them on leave so there's no error later? Or keep them in case the user rejoins?

--- a/Izzy-Moonbot/EventListeners/UserListener.cs
+++ b/Izzy-Moonbot/EventListeners/UserListener.cs
@@ -222,10 +222,10 @@ public class UserListener
         var output = $"Leave: {user.Username}#{user.Discriminator} ({lastNickname}) (`{user.Id}`) joined <t:{_users[user.Id].Joins.Last().ToUnixTimeSeconds()}:R>";
 
         if (banAuditLog != null)
-            output += $"\n\nAccording to the server audit log, they were **banned** at {banAuditLog.CreatedAt} by {banAuditLog.User.Username}#{banAuditLog.User.Discriminator} ({guild.GetUser(banAuditLog.User.Id).DisplayName}) for the following reason:\n\"{banAuditLog.Reason}\"";
+            output += $"\n\nAccording to the server audit log, they were **banned** at <t:{banAuditLog.CreatedAt.ToUnixTimeSeconds()}:R> by {banAuditLog.User.Username}#{banAuditLog.User.Discriminator} ({guild.GetUser(banAuditLog.User.Id).DisplayName}) for the following reason:\n\"{banAuditLog.Reason}\"";
 
         if (kickAuditLog != null)
-            output += $"\n\nAccording to the server audit log, they were **kicked** at {kickAuditLog.CreatedAt} by {kickAuditLog.User.Username}#{kickAuditLog.User.Discriminator} ({guild.GetUser(kickAuditLog.User.Id).DisplayName}) for the following reason:\n\"{kickAuditLog.Reason}\"";
+            output += $"\n\nAccording to the server audit log, they were **kicked** at <t:{kickAuditLog.CreatedAt.ToUnixTimeSeconds()}:R> by {kickAuditLog.User.Username}#{kickAuditLog.User.Discriminator} ({guild.GetUser(kickAuditLog.User.Id).DisplayName}) for the following reason:\n\"{kickAuditLog.Reason}\"";
 
         // Scheduled jobs that require a user to be in the server create a difficult question.
         // Do we delete them on leave so there's no error later? Or keep them in case the user rejoins?

--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -456,7 +456,7 @@ public static class DiscordHelper
         // but some of them are still useful to make the message clearer
         return $"Command `{context.Message.Content}` " +
             $"was run by {user.Username}#{user.Discriminator} ({user.Id}) " +
-            $"in #{channel.Name} ({channel.Id}) " +
+            $"in #{channel.Name} (<#{channel.Id}>) " +
             $"at {now} (<t:{now.ToUnixTimeMilliseconds()}>)";
     }
 }


### PR DESCRIPTION
I can't directly kick/ban anyone on the test server, so I can only test the .ban case, which is the most verbose since Izzy's audit log reason says a lot about the .ban command in addition to who got banned:

![image](https://github.com/Manechat/izzy-moonbot/assets/5285357/62e3df1b-57c9-4977-ac40-fc3b35247f9c)

The more common case of a mod "hoof-banning" someone in the server should have changed from something like this:
> Leave (Ban): CajunSpice#8376 (CajunSpice) (754843342856257558) joined 3 days ago, "" by Mercy-`#`0001 (Mercurial.mp4)

to something like this:
> Leave: CajunSpice#8376 (CajunSpice) (754843342856257558) joined 3 days ago
> 
> According to the server audit log, they were **banned** at 26/05/2023 17:36:30 +00:00 by Mercy-`#`0001 (Mercurial.mp4) for the following reason:
> ""

Closes #405 