### PR TITLE
#421 Unbreak quote pagination formatting

### DIFF
--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -205,8 +205,10 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
 
         PaginationHelper.PaginateIfNeededAndSendMessage(
             context,
-            $"Here's all the quotes I have for **{await DisplayUserName(userId, context.Client, defaultGuild)}**:\n",
-            quotes.Select((quote, index) => $"{index + 1}. {quote}").Select(SanitizeQuote).ToArray(),
+            $"Here's all the quotes I have for **{await DisplayUserName(userId, context.Client, defaultGuild)}**:",
+            // We put a \ before the . to prevent Discord's numbered list markdown formatting from kicking in, since
+            // that not only adds weird spacing and margins, but also changes the quote numbers in some cases.
+            quotes.Select((quote, index) => $"{index + 1}\\. {quote}").Select(SanitizeQuote).ToArray(),
             $"\nRun `{_config.Prefix}quote <user> <number>` to get a specific quote.\n" +
             $"Run `{_config.Prefix}quote <user>` to get a random quote from that user.\n" +
             $"Run `{_config.Prefix}quote` for a random quote from a random user.",

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -225,8 +225,8 @@ public class QuoteModuleTests
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, $"for **{sunny.DisplayName}**:");
         StringAssert.Contains(description, "\n" +
-            "1\. gonna be my day\n" +
-            "2\. gonna be my day\n" +
+            "1\\. gonna be my day\n" +
+            "2\\. gonna be my day\n" +
             "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -116,8 +116,8 @@ public class QuoteModuleTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, $"for **{izzy.DisplayName}**:");
-        StringAssert.Contains(description, "\n\n" +
-            $"1. let's unicycle it\n" +
+        StringAssert.Contains(description, "\n" +
+            $"1\\. let's unicycle it\n" +
             "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");
@@ -131,9 +131,9 @@ public class QuoteModuleTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, $"for **{sunny.DisplayName}**:");
-        StringAssert.Contains(description, "\n\n" +
-            "1. gonna be my day\n" +
-            "2. eat more vegetables\n" +
+        StringAssert.Contains(description, "\n" +
+            "1\\. gonna be my day\n" +
+            "2\\. eat more vegetables\n" +
             "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");
@@ -161,9 +161,9 @@ public class QuoteModuleTests
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, $"for **{pipp.DisplayName}**:");
-        StringAssert.Contains(description, "\n\n" +
-            "1. Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!\n" +
-            "2. It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! <https://youtu.be/CLT4aSurqCg>\n" +
+        StringAssert.Contains(description, "\n" +
+            "1\\. Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!\n" +
+            "2\\. It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! <https://youtu.be/CLT4aSurqCg>\n" +
             "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");
@@ -224,9 +224,9 @@ public class QuoteModuleTests
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
         StringAssert.Contains(description, $"for **{sunny.DisplayName}**:");
-        StringAssert.Contains(description, "\n\n" +
-            "1. gonna be my day\n" +
-            "2. gonna be my day\n" +
+        StringAssert.Contains(description, "\n" +
+            "1\. gonna be my day\n" +
+            "2\. gonna be my day\n" +
             "\n");
         StringAssert.Contains(description, "Run `.quote <user> <number>` to");
         StringAssert.Contains(description, "Run `.quote <user>` to");


### PR DESCRIPTION
Fixes #421 

Discord's numbered list formatting sometimes changes quote numbers from Izzy's output into clearly incorrect numbers. Apparently that logic hardcodes the number 50 as a special case, so the easiest way to reproduce it is to have more than 50 quotes for a user and then have a multiline quote after 50:
<img width="354" alt="image" src="https://github.com/Manechat/izzy-moonbot/assets/5285357/51849e7a-6d1e-4f00-9d50-7a1ab61b78fa">
The recent markdown change also did weird things to the margins and spacing of this list which I don't think we want.

Simply escaping the . works around all of this by making Discord markdown no longer perceive it as a numbered list:
<img width="345" alt="image" src="https://github.com/Manechat/izzy-moonbot/assets/5285357/ac302119-0e06-4840-8062-224f40da8857">

I also removed an unnecessary newline from the header string that Merc pointed out.