### PR TITLE
update to Discord.NET 3.11 for the new username system

### DIFF
--- a/Izzy-Moonbot/Izzy-Moonbot.csproj
+++ b/Izzy-Moonbot/Izzy-Moonbot.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Discord.Net" Version="3.10.0" />
+        <PackageReference Include="Discord.Net" Version="3.11.0" />
         <PackageReference Include="Flurl.Http" Version="3.2.4" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/Izzy-MoonbotTests/Tests/TestAdapters.cs
+++ b/Izzy-MoonbotTests/Tests/TestAdapters.cs
@@ -201,6 +201,8 @@ public class TestAttachment : IAttachment
     public bool Ephemeral => throw new NotImplementedException();
     public string Description => _fileAttachment.Description;
     public string ContentType => throw new NotImplementedException();
+    double? IAttachment.Duration => throw new NotImplementedException();
+    string IAttachment.Waveform => throw new NotImplementedException();
 }
 
 public class StubChannel


### PR DESCRIPTION
unblocks #409

I'm guessing dependabot waits a while before creating PRs, but this is one we'd like to adopt soon, and it looks like the update "just works" for us after making a small fix to TestAdapters.cs.