### PR TITLE
Username changes

### DIFF
--- a/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
+++ b/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
@@ -20,6 +20,7 @@ public class DiscordNetUserAdapter : IIzzyUser
 
     public ulong Id { get => _user.Id; }
     public string Username { get => _user.Username; }
+    public string? GlobalName { get => _user.GlobalName; }
     public string Discriminator { get => _user.Discriminator; }
     public bool IsBot => _user.IsBot;
     public async Task<IIzzyUserMessage> SendMessageAsync(string text) =>
@@ -42,6 +43,8 @@ public class SocketGuildUserAdapter : IIzzyGuildUser
 
     public ulong Id { get => _user.Id; }
     public string Username { get => _user.Username; }
+    public string? GlobalName { get => _user.GlobalName; }
+    public string? Nickname { get => _user.Nickname; }
     public string Discriminator { get => _user.Discriminator; }
     public string DisplayName { get => _user.DisplayName; }
     public int Hierarchy { get => _user.Hierarchy; }

--- a/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
+++ b/Izzy-Moonbot/Adapters/DiscordNetAdapters.cs
@@ -21,7 +21,6 @@ public class DiscordNetUserAdapter : IIzzyUser
     public ulong Id { get => _user.Id; }
     public string Username { get => _user.Username; }
     public string? GlobalName { get => _user.GlobalName; }
-    public string Discriminator { get => _user.Discriminator; }
     public bool IsBot => _user.IsBot;
     public async Task<IIzzyUserMessage> SendMessageAsync(string text) =>
         new DiscordNetUserMessageAdapter(await _user.SendMessageAsync(text));
@@ -45,7 +44,6 @@ public class SocketGuildUserAdapter : IIzzyGuildUser
     public string Username { get => _user.Username; }
     public string? GlobalName { get => _user.GlobalName; }
     public string? Nickname { get => _user.Nickname; }
-    public string Discriminator { get => _user.Discriminator; }
     public string DisplayName { get => _user.DisplayName; }
     public int Hierarchy { get => _user.Hierarchy; }
     public bool IsBot => _user.IsBot;

--- a/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
+++ b/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
@@ -9,6 +9,7 @@ public interface IIzzyUser
 {
     ulong Id { get; }
     string Username { get; }
+    string? GlobalName { get; }
     string Discriminator { get => "1234"; }
     bool IsBot { get; }
 }
@@ -16,6 +17,7 @@ public interface IIzzyUser
 public interface IIzzyGuildUser : IIzzyUser
 {
     string DisplayName { get; }
+    string? Nickname { get; }
     int Hierarchy => DisplayName.Contains("Izzy") ? 1 : 0; // not used enough to be worth accurately imitating in tests
     IReadOnlyCollection<IIzzyRole> Roles { get; }
 

--- a/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
+++ b/Izzy-Moonbot/Adapters/IzzyInterfaces.cs
@@ -10,7 +10,6 @@ public interface IIzzyUser
     ulong Id { get; }
     string Username { get; }
     string? GlobalName { get; }
-    string Discriminator { get => "1234"; }
     bool IsBot { get; }
 }
 

--- a/Izzy-Moonbot/EventListeners/MessageListener.cs
+++ b/Izzy-Moonbot/EventListeners/MessageListener.cs
@@ -57,7 +57,7 @@ public class MessageListener
         if (author.IsBot) return; // Don't listen to bots
 
         var logMessage =
-            $"Message {newMessage.Id} by {author.Username}#{author.Discriminator} ({author.Id}) **edited** in {channel.Name}:\n" +
+            $"Message {newMessage.Id} by {DiscordHelper.DisplayName(author, defaultGuild)} ({author.Username}/{author.Id}) **edited** in {channel.Name}:\n" +
             $"__Before__:\n{oldContent}\n" +
             $"__After__:\n{newMessage.Content}";
 
@@ -89,7 +89,7 @@ public class MessageListener
         if (author.Id == client.CurrentUser.Id) return; // Don't process self.
         if (author.IsBot) return; // Don't listen to bots
 
-        var logMessage = $"Message id {messageId} by {author.Username}#{author.Discriminator} ({author.Id}) **deleted**";
+        var logMessage = $"Message id {messageId} by {DiscordHelper.DisplayName(author, defaultGuild)} ({author.Username}/{author.Id}) **deleted**";
 
         if (channel is null)
             logMessage += $" in unknown channel {channelId}:\n";

--- a/Izzy-Moonbot/Modules/DevModule.cs
+++ b/Izzy-Moonbot/Modules/DevModule.cs
@@ -262,27 +262,6 @@ public class DevModule : ModuleBase<SocketCommandContext>
                         $"{(time.RepeatType is ScheduledJobRepeatType.None ? "" : $" repeating {time.RepeatType}")}\n" +
                     $"with remainingArgsString: \"{remainingArgsString}\"");
                 break;
-            case "getuser":
-                if (ulong.TryParse(args[0], out var id))
-                {
-                    var user = await Context.Client.GetUserAsync(id);
-
-                    if (user == null)
-                    {
-                        await ReplyAsync("Couldn't find user");
-                    }
-                    else
-                    {
-                        await ReplyAsync($"User info:\n" +
-                                         $"Id: {id}\n" +
-                                         $"Name: {user.Username}#{user.Discriminator}");
-                    }
-                }
-                else
-                {
-                    await ReplyAsync($"not valid user");
-                }
-                break;
             case "customArgument":
                 var customArgument_Result = DiscordHelper.GetArguments(argString);
 

--- a/Izzy-Moonbot/Modules/ModCoreModule.cs
+++ b/Izzy-Moonbot/Modules/ModCoreModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -95,10 +95,12 @@ public class ModCoreModule : ModuleBase<SocketCommandContext>
             if (discordUser == null)
                 return "I couldn't find that user, sorry!";
 
-            output += $"**User:** `<@{discordUser.Id}>` {discordUser.Username} ({discordUser.Id})\n";
+            output += $"**User:** `<@{discordUser.Id}>` {DiscordHelper.DisplayName(discordUser, guild)} ({discordUser.Username}/{discordUser.Id})\n";
+            output += $"**{guild.Name} Server Nickname**: None (user isn't in this server)\n";
+            output += $"**Global Display Name**: {discordUser.GlobalName ?? "None"}\n";
             output += users.ContainsKey(discordUser.Id)
-                ? $"**Names:** {string.Join(", ", users[discordUser.Id].Aliases)}\n"
-                : $"**Names:** None (user isn't known by Izzy)\n";
+                ? $"**All Known Names:** {string.Join(", ", users[discordUser.Id].Aliases)}\n"
+                : $"**All Known Names:** None (user isn't known by Izzy)\n";
             output += $"**Roles:** None (user isn't in this server)\n";
             output += "**History:** ";
             output += $"Created <t:{discordUser.CreatedAt.ToUnixTimeSeconds()}:R>";
@@ -111,8 +113,10 @@ public class ModCoreModule : ModuleBase<SocketCommandContext>
         }
         else
         {
-            output += $"**User:** `<@{member.Id}>` {member.Username} ({member.Id})\n";
-            output += $"**Names:** {string.Join(", ", users[member.Id].Aliases)}\n";
+            output += $"**User:** `<@{member.Id}>` {member.DisplayName} ({member.Username}/{member.Id})\n";
+            output += $"**{guild.Name} Server Nickname**: {member.Nickname ?? "None"}\n";
+            output += $"**Global Display Name**: {member.GlobalName ?? "None"}\n";
+            output += $"**All Known Names:** {string.Join(", ", users[member.Id].Aliases)}\n";
             output +=
                 $"**Roles:** {string.Join(", ", member.Roles.Where(role => role.Id != guildId).Select(role => role.Name))}\n";
             output += $"**History:** ";
@@ -240,7 +244,7 @@ public class ModCoreModule : ModuleBase<SocketCommandContext>
                 msg += "\n\n" +
                     $"Here's a userlog I unicycled that you can use if you want to!\n```\n" +
                     $"Type: Ban ({(timeArg == "" ? "" : $"{timeArg} ")}{(time == null ? "Indefinite" : $"<t:{time.Time.ToUnixTimeSeconds()}:R>")})\n" +
-                    $"User: <@{userId}> {(member != null ? $"({member.Username}#{member.Discriminator})" : "")} ({userId})\n" +
+                    $"User: <@{userId}> ({userId})\n" +
                     $"Names: {(_users.ContainsKey(userId) ? string.Join(", ", _users[userId].Aliases) : "None (user isn't known by Izzy)")}\n" +
                     $"```";
             }
@@ -268,7 +272,7 @@ public class ModCoreModule : ModuleBase<SocketCommandContext>
                         msg += "\n\n" +
                             $"Here's a userlog I unicycled that you can use if you want to!\n```\n" +
                             $"Type: Ban (Indefinite)\n" +
-                            $"User: <@{userId}> {(member != null ? $"({member.Username}#{member.Discriminator})" : "")} ({userId})\n" +
+                            $"User: <@{userId}> ({(member != null ? $"{member.Username}/" : "")}{userId})\n" +
                             $"Names: {(_users.ContainsKey(userId) ? string.Join(", ", _users[userId].Aliases) : "None (user isn't known by Izzy)")}\n" +
                             $"```";
                     }
@@ -310,7 +314,7 @@ public class ModCoreModule : ModuleBase<SocketCommandContext>
                     msg += "\n\n" +
                         $"Here's a userlog I unicycled that you can use if you want to!\n```\n" +
                         $"Type: Ban ({timeArg} <t:{time.Time.ToUnixTimeSeconds()}:R>)\n" +
-                        $"User: <@{userId}> {(member != null ? $"({member.Username}#{member.Discriminator})" : "")} ({userId})\n" +
+                        $"User: <@{userId}> ({(member != null ? $"{member.Username}/" : "")}{userId})\n" +
                         $"Names: {(_users.ContainsKey(userId) ? string.Join(", ", _users[userId].Aliases) : "None (user isn't known by Izzy)")}\n" +
                         $"```";
                 }
@@ -330,7 +334,7 @@ public class ModCoreModule : ModuleBase<SocketCommandContext>
                     msg += "\n\n" +
                         $"Here's a userlog I unicycled that you can use if you want to!\n```\n" +
                         $"Type: Ban ({timeArg} <t:{time.Time.ToUnixTimeSeconds()}:R>)\n" +
-                        $"User: <@{userId}> {(member != null ? $"({member.Username}#{member.Discriminator})" : "")} ({userId})\n" +
+                        $"User: <@{userId}> ({(member != null ? $"{member.Username}/" : "")}{userId})\n" +
                         $"Names: {(_users.ContainsKey(userId) ? string.Join(", ", _users[userId].Aliases) : "None (user isn't known by Izzy)")}\n" +
                         $"```";
                 }

--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -360,7 +360,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             await _quoteService.RemoveQuote(quoteUser, number.Value - 1);
 
             await context.Channel.SendMessageAsync(
-                $"Removed quote #{number.Value} from **{quoteUser.Username}#{quoteUser.Discriminator}**.", allowedMentions: AllowedMentions.None);
+                $"Removed quote #{number.Value} from **{quoteUser.DisplayName}** ({quoteUser.Username}).", allowedMentions: AllowedMentions.None);
             return;
         }
 
@@ -444,7 +444,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                     throw new TargetException("The user this alias referenced to cannot be found.");
 
                 await context.Channel.SendMessageAsync(
-                    $"Quote alias **{alias}** maps to user **{user.Username}#{user.Discriminator}**.", allowedMentions: AllowedMentions.None);
+                    $"Quote alias **{alias}** maps to user **{user.DisplayName}** ({user.Username}).", allowedMentions: AllowedMentions.None);
             }
         }
         else if (operation.ToLower() == "set" || operation.ToLower() == "add")

--- a/Izzy-Moonbot/Modules/RaidModule.cs
+++ b/Izzy-Moonbot/Modules/RaidModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord.Commands;
@@ -96,7 +96,7 @@ public class RaidModule : ModuleBase<SocketCommandContext>
 
         await ReplyAsync($"The following users are recent joins:\n" +
             "```\n" +
-            string.Join(", ", recentJoins.Select(user => $"{user.Username}#{user.Discriminator}")) + "\n" +
+            string.Join(", ", recentJoins.Select(user => $"{user.DisplayName} ({user.Username}/{user.Id})")) + "\n" +
             "```");
     }
 }

--- a/Izzy-Moonbot/Modules/SpamModule.cs
+++ b/Izzy-Moonbot/Modules/SpamModule.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using Discord.Commands;
 using Izzy_Moonbot.Adapters;
@@ -49,7 +49,7 @@ public class SpamModule : ModuleBase<SocketCommandContext>
         {
             double pressure = _spamService.GetPressure(user.Id);
 
-            await context.Channel.SendMessageAsync($"Current Pressure for {user.Username}#{user.Discriminator}: {pressure}");
+            await context.Channel.SendMessageAsync($"Current Pressure for {user.DisplayName} ({user.Username}/{user.Id}): {pressure}");
         }
     }
 
@@ -90,7 +90,7 @@ public class SpamModule : ModuleBase<SocketCommandContext>
             );
 
             await context.Channel.SendMessageAsync(
-                $"I consider the following messages from {user.Username}#{user.Discriminator} to be recent: \n{string.Join('\n', messageList)}\n*Note that these messages may not actually be recent as their age is only checked when the user sends more messages.*");
+                $"I consider the following messages from {user.DisplayName} ({user.Username}/{user.Id}) to be recent: \n{string.Join('\n', messageList)}\n*Note that these messages may not actually be recent as their age is only checked when the user sends more messages.*");
         }
     }
 }

--- a/Izzy-Moonbot/Service/FilterService.cs
+++ b/Izzy-Moonbot/Service/FilterService.cs
@@ -90,7 +90,7 @@ public class FilterService
         await _modLog.CreateModLog(context.Guild)
             .SetContent($"{(actionsTaken.Contains("silence") ? $"<@&{_config.ModRole}>" : "")} Filter Violation for <@{context.User.Id}>")
             .SetEmbed(embedBuilder.Build())
-            .SetFileLogContent($"Filter violation by {context.User.Username}#{context.User.Discriminator} ({context.Guild.GetUser(context.User.Id)?.DisplayName}) (`{context.User.Id}`) in #{context.Channel.Name} (`{context.Channel.Id}`)\n" +
+            .SetFileLogContent($"Filter violation by {DiscordHelper.DisplayName(context.User, context.Guild)} (`{context.User.Username}`/`{context.User.Id}`) in #{context.Channel.Name} (`{context.Channel.Id}`)\n" +
                                $"Trigger: {context.Message.CleanContent.Replace(word, $"[[{word}]]")}\n" +
                                $"Response: {fileLogResponse}")
             .Send();

--- a/Izzy-Moonbot/Service/LoggingService.cs
+++ b/Izzy-Moonbot/Service/LoggingService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using Discord.Commands;
 using Izzy_Moonbot.Adapters;
@@ -57,7 +57,7 @@ public class LoggingService
         {
             if (context.IsPrivate)
             {
-                logMessage += $"DM with @{context.User.Username}#{context.User.Discriminator} ({context.User.Id})";
+                logMessage += $"DM with @{context.User.Username} ({context.User.Id})";
 
                 logMessage += ", ";
 
@@ -69,7 +69,7 @@ public class LoggingService
 
                 logMessage += " ";
 
-                logMessage += $"@{context.User.Username}#{context.User.Discriminator} ({context.User.Id}), ";
+                logMessage += $"@{context.User.Username} ({context.User.Id}), ";
                 logMessage += message;
             }
         }

--- a/Izzy-Moonbot/Service/QuoteService.cs
+++ b/Izzy-Moonbot/Service/QuoteService.cs
@@ -90,7 +90,7 @@ public class QuoteService
             if (potentialUser == null)
                 return _users.TryGetValue(id, out var user) ? $"{id} ({user.Username}) {aliasText}" : $"{id} {aliasText}";
 
-            return $"{potentialUser.DisplayName} ({potentialUser.Username}#{potentialUser.Discriminator}) {aliasText}";
+            return $"{potentialUser.DisplayName} ({potentialUser.Username}/{potentialUser.Id}) {aliasText}";
         }).ToArray();
     }
 

--- a/Izzy-Moonbot/Service/RaidService.cs
+++ b/Izzy-Moonbot/Service/RaidService.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Discord;
 using Discord.WebSocket;
 using Izzy_Moonbot.Helpers;
 using Izzy_Moonbot.Settings;
@@ -76,11 +77,10 @@ public class RaidService
         {
             var joinDate = "`Couldn't get member join time`";
             if (member.JoinedAt.HasValue) joinDate = $"<t:{member.JoinedAt.Value.ToUnixTimeSeconds()}:F>";
-            raiderDescriptions.Add($"<@{member.Id}> {member.Username}#{member.Discriminator} (joined: {joinDate})");
+            raiderDescriptions.Add($"<@{member.Id}> {member.DisplayName} ({member.Username}/{member.Id}) (joined: {joinDate})");
         });
         return string.Join($"\n", raiderDescriptions);
     }
-
     private async Task TripSmallRaid(SocketGuild guild, List<SocketGuildUser> recentJoins)
     {
         _log.Log("Small raid detected!");
@@ -211,7 +211,7 @@ public class RaidService
         if (!_config.RaidProtectionEnabled) return;
         if (_state.RecentJoins.Contains(member.Id))
         {
-            _log.Log($"{member.DisplayName}#{member.Discriminator} ({member.Id}) rejoined while still considered a recent join. Not updating recent joins list.");
+            _log.Log($"{member.DisplayName} ({member.Username}/{member.Id}) rejoined while still considered a recent join. Not updating recent joins list.");
             return;
         }
 

--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -253,14 +253,14 @@ public class ScheduleService
         var reason = job.Reason;
         
         _logger.Log(
-            $"Adding {role.Name} ({role.Id}) to {user.Username}#{user.Discriminator} ({user.Id})", level: LogLevel.Debug);
+            $"Adding {role.Name} ({role.Id}) to {user.DisplayName} ({user.Username}/{user.Id})", level: LogLevel.Debug);
         
         await _mod.AddRole(user, role.Id, reason);
         await _modLogging.CreateModLog(guild)
             .SetContent(
                 $"Gave <@&{role.Id}> to <@{user.Id}> (`{user.Id}`).")
             .SetFileLogContent(
-                $"Gave {role.Name} ({role.Id}) to {user.Username}#{user.Discriminator} ({user.Id}). {(reason != null ? $"Reason: {reason}." : "")}")
+                $"Gave {role.Name} ({role.Id}) to {user.DisplayName} ({user.Username}/{user.Id}). {(reason != null ? $"Reason: {reason}." : "")}")
             .Send();
     }
     
@@ -285,14 +285,14 @@ public class ScheduleService
         string? reason = job.Reason;
         
         _logger.Log(
-            $"Removing {role.Name} ({role.Id}) from {user.Username}#{user.Discriminator} ({user.Id})", level: LogLevel.Debug);
+            $"Removing {role.Name} ({role.Id}) from {user.DisplayName} ({user.Username}/{user.Id})", level: LogLevel.Debug);
         
         await _mod.RemoveRole(user, role.Id, reason);
         await _modLogging.CreateModLog(guild)
             .SetContent(
                 $"Removed <@&{role.Id}> from <@{user.Id}> (`{user.Id}`)")
             .SetFileLogContent(
-                $"Removed {role.Name} ({role.Id}) from {user.Username}#{user.Discriminator} ({user.Id}). {(reason != null ? $"Reason: {reason}." : "")}")
+                $"Removed {role.Name} ({role.Id}) from {user.DisplayName} ({user.Username}/{user.Id}). {(reason != null ? $"Reason: {reason}." : "")}")
             .Send();
     }
 
@@ -310,14 +310,14 @@ public class ScheduleService
 
         var embed = new EmbedBuilder()
             .WithTitle(
-                $"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator}" : "")} ({job.User})")
+                $"Unbanned {(user != null ? $"{DiscordHelper.DisplayName(user, guild)} ({user.Username}/{user.Id})" : "")}")
             .WithColor(16737792)
             .WithDescription($"Gasp! Does this mean I can invite <@{job.User}> to our next traditional unicorn sleepover?")
             .Build();
         
         await _modLogging.CreateModLog(guild)
             .SetEmbed(embed)
-            .SetFileLogContent($"Unbanned {(user != null ? $"{user.Username}#{user.Discriminator}" : "")} ({job.User})")
+            .SetFileLogContent($"Unbanned {job.User}")
             .Send();
     }
 

--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -284,7 +284,7 @@ public class SpamService
                     .SetContent($"Spam detected by <@{user.Id}>")
                     .SetEmbed(embedBuilder.Build())
                     .SetFileLogContent(
-                        $"{user.Username}#{user.Discriminator} ({user.DisplayName}) (`{user.Id}`) exceeded pressure max ({newPressure}/{_config.SpamMaxPressure}) in #{message.Channel.Name} (`{message.Channel.Id}`).\n" +
+                        $"{user.DisplayName} (`{user.Username}`/`{user.Id}`) exceeded pressure max ({newPressure}/{_config.SpamMaxPressure}) in #{message.Channel.Name} (`{message.Channel.Id}`).\n" +
                         $"Pressure breakdown: {PonyReadableBreakdown(pressureBreakdown)}\n" +
                         $"Did nothing: User has a role which bypasses punishment or has dev bypass.") 
                     .Send();
@@ -406,7 +406,7 @@ public class SpamService
             )
             .SetEmbed(embedBuilder.Build())
             .SetFileLogContent(
-                $"{user.Username}#{user.Discriminator} ({user.DisplayName}) (`{user.Id}`) was silenced/timed out for exceeding pressure max ({pressure}/{_config.SpamMaxPressure}) in #{message.Channel.Name} (`{message.Channel.Id}`).\n" +
+                $"{user.DisplayName} (`{user.Username}`/`{user.Id}`) was silenced/timed out for exceeding pressure max ({pressure}/{_config.SpamMaxPressure}) in #{message.Channel.Name} (`{message.Channel.Id}`).\n" +
                 $"Pressure breakdown: {PonyReadableBreakdown(pressureBreakdown)}\n" +
                 $"{(alreadyDeletedMessages != 0 ? $"I was unable to delete {alreadyDeletedMessages} messages from this user, please double check whether their messages have been deleted." : "")}")
             .Send();

--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -442,7 +442,7 @@ namespace Izzy_Moonbot
                 if (stowawaySet.Count != 0)
                 {
                     var stowawayStringList = stowawaySet.Select(user => $"<@{user.Id}>");
-                    var stowawayStringFileList = stowawaySet.Select(user => $"{user.Username}#{user.Discriminator}");
+                    var stowawayStringFileList = stowawaySet.Select(user => $"{user.DisplayName} ({user.Username}/{user.Id})");
                     
                     await _modLog.CreateModLog(guild)
                         .SetContent($"I found these stowaways after I rebooted, cannot tell if they're new users:\n" +

--- a/Izzy-MoonbotTests/Tests/LoggingServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/LoggingServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Izzy_Moonbot;
+using Izzy_Moonbot;
 using Izzy_Moonbot.Service;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -36,7 +36,7 @@ public class LoggingServiceTests
         logService.Log("sunny said something", context);
         TestUtils.AssertListsAreEqual(new List<string> {
             $"[LoggingServiceTests.cs:BasicTests:30] test",
-            $"[LoggingServiceTests.cs:BasicTests:36] server: Maretime Bay ({guild.Id}) #general ({generalChannel.Id}) @Sunny#1234 ({sunny.Id}), sunny said something"
+            $"[LoggingServiceTests.cs:BasicTests:36] server: Maretime Bay ({guild.Id}) #general ({generalChannel.Id}) @Sunny ({sunny.Id}), sunny said something"
         }, logger.Logs);
     }
 }

--- a/Izzy-MoonbotTests/Tests/ModCoreModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/ModCoreModuleTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Izzy_Moonbot.Helpers;
 using Izzy_Moonbot.Settings;
 using Izzy_Moonbot.Service;
@@ -72,7 +72,7 @@ public class ModCoreModuleTests
         await ss.Unicycle(client);
 
         Assert.AreEqual(1, modChat.Messages.Last().Embeds.Count);
-        Assert.AreEqual("Unbanned Pipp#1234 (4)", modChat.Messages.Last().Embeds.Last().Title);
+        Assert.AreEqual("Unbanned Pipp (Pipp/4)", modChat.Messages.Last().Embeds.Last().Title);
         TestUtils.AssertSetsAreEqual(new HashSet<ulong> { hitchId }, guild.BannedUserIds);
         Assert.AreEqual(1, ss.GetScheduledJobs().Count);
 
@@ -80,7 +80,7 @@ public class ModCoreModuleTests
         await ss.Unicycle(client);
 
         Assert.AreEqual(1, modChat.Messages.Last().Embeds.Count);
-        Assert.AreEqual("Unbanned Hitch#1234 (5)", modChat.Messages.Last().Embeds.Last().Title);
+        Assert.AreEqual("Unbanned Hitch (Hitch/5)", modChat.Messages.Last().Embeds.Last().Title);
         TestUtils.AssertSetsAreEqual(new HashSet<ulong>(), guild.BannedUserIds);
         Assert.AreEqual(0, ss.GetScheduledJobs().Count);
 

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Izzy_Moonbot.Helpers;
 using Izzy_Moonbot.Settings;
 using Izzy_Moonbot.Service;
@@ -29,25 +29,25 @@ public class QuoteModuleTests
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote");
         await qm.TestableQuoteCommandAsync(context, "");
-        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.GlobalName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
 
         //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".quote Sunny");
         await qm.TestableQuoteCommandAsync(context, "Sunny");
-        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.GlobalName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
 
         //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}>");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}>");
-        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.GlobalName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
 
         //
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}> 1");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}> 1");
-        Assert.AreEqual($"**{sunny.DisplayName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"**{sunny.GlobalName}**, #1: gonna be my day", generalChannel.Messages.Last().Content);
 
         //
 
@@ -115,7 +115,7 @@ public class QuoteModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, $"for **{izzy.DisplayName}**:");
+        StringAssert.Contains(description, $"for **{izzy.GlobalName}**:");
         StringAssert.Contains(description, "\n" +
             $"1\\. let's unicycle it\n" +
             "\n");
@@ -130,7 +130,7 @@ public class QuoteModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, $"for **{sunny.DisplayName}**:");
+        StringAssert.Contains(description, $"for **{sunny.GlobalName}**:");
         StringAssert.Contains(description, "\n" +
             "1\\. gonna be my day\n" +
             "2\\. eat more vegetables\n" +
@@ -160,7 +160,7 @@ public class QuoteModuleTests
 
         description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, $"for **{pipp.DisplayName}**:");
+        StringAssert.Contains(description, $"for **{pipp.GlobalName}**:");
         StringAssert.Contains(description, "\n" +
             "1\\. Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!\n" +
             "2\\. It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! <https://youtu.be/CLT4aSurqCg>\n" +
@@ -223,7 +223,7 @@ public class QuoteModuleTests
 
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "all the quotes");
-        StringAssert.Contains(description, $"for **{sunny.DisplayName}**:");
+        StringAssert.Contains(description, $"for **{sunny.GlobalName}**:");
         StringAssert.Contains(description, "\n" +
             "1\\. gonna be my day\n" +
             "2\\. gonna be my day\n" +
@@ -264,7 +264,7 @@ public class QuoteModuleTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote Sunny eat more vegetables");
         await qm.TestableAddQuoteCommandAsync(context, "Sunny eat more vegetables");
 
-        Assert.AreEqual($"Added quote #2 to **{sunny.DisplayName}**:\n" +
+        Assert.AreEqual($"Added quote #2 to **{sunny.GlobalName}**:\n" +
             "\n" +
             ">>> eat more vegetables", generalChannel.Messages.Last().Content);
         TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
@@ -277,7 +277,7 @@ public class QuoteModuleTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote Pipp Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!");
         await qm.TestableAddQuoteCommandAsync(context, "Pipp Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!");
 
-        Assert.AreEqual($"Added quote #1 to **{pipp.DisplayName}**:\n" +
+        Assert.AreEqual($"Added quote #1 to **{pipp.GlobalName}**:\n" +
             "\n" +
             ">>> Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!", generalChannel.Messages.Last().Content);
 
@@ -286,7 +286,7 @@ public class QuoteModuleTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".addquote It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! https://youtu.be/CLT4aSurqCg");
         await qm.TestableAddQuoteCommandAsync(context, "Pipp It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! https://youtu.be/CLT4aSurqCg");
 
-        Assert.AreEqual($"Added quote #2 to **{pipp.DisplayName}**:\n" +
+        Assert.AreEqual($"Added quote #2 to **{pipp.GlobalName}**:\n" +
             "\n" +
             ">>> It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! <https://youtu.be/CLT4aSurqCg>", generalChannel.Messages.Last().Content);
 
@@ -306,7 +306,7 @@ public class QuoteModuleTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".removequote <@{sunny.Id}> 1");
         await qm.TestableRemoveQuoteCommandAsync(context, $"<@{sunny.Id}> 1");
 
-        Assert.AreEqual($"Removed quote #1 from **{sunny.DisplayName}**.", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"Removed quote #1 from **{sunny.GlobalName}**.", generalChannel.Messages.Last().Content);
         TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
             "eat more vegetables"
         });

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -101,9 +101,9 @@ public class QuoteModuleTests
         var description = generalChannel.Messages.Last().Content;
         StringAssert.Contains(description, "Here's all the");
         StringAssert.Contains(description, "```\n" +
-            "Sunny (Sunny#1234) \n" +
-            "Izzy Moonbot (Izzy Moonbot#1234) \n" +
-            "Pipp (Pipp#1234) \n" +
+            "Sunny (Sunny/2) \n" +
+            "Izzy Moonbot (Izzy Moonbot/1) \n" +
+            "Pipp (Pipp/4) \n" +
             "```\n");
         StringAssert.Contains(description, "Run `.quote <user>`");
         StringAssert.Contains(description, "Run `.quote`");

--- a/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Izzy_Moonbot.Adapters;
 using Izzy_Moonbot.Settings;
 using Izzy_Moonbot.Service;
@@ -26,7 +26,7 @@ public class QuoteServiceTests
 
         Assert.AreEqual((0, "gonna be my day"), qs.GetRandomQuote(sunny.Id));
 
-        TestUtils.AssertListsAreEqual(new List<string> { "Sunny (Sunny#1234) " }, qs.GetKeyList(testGuild));
+        TestUtils.AssertListsAreEqual(new List<string> { "Sunny (Sunny/2) " }, qs.GetKeyList(testGuild));
 
         Assert.AreEqual("gonna be my day", qs.GetQuote(sunny.Id, 0));
 

--- a/Izzy-MoonbotTests/Tests/SpamModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/SpamModuleTests.cs
@@ -1,4 +1,4 @@
-﻿using Izzy_Moonbot;
+using Izzy_Moonbot;
 using Izzy_Moonbot.Helpers;
 using Izzy_Moonbot.Modules;
 using Izzy_Moonbot.Service;
@@ -39,7 +39,7 @@ public class SpamModuleTests
         await sm.TestableGetPressureAsync(context, "");
 
         var firstPressure = cfg.SpamBasePressure + commandLengthPenalty;
-        Assert.AreEqual($"Current Pressure for Sunny#1234: {firstPressure}", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"Current Pressure for Sunny (Sunny/2): {firstPressure}", generalChannel.Messages.Last().Content);
 
         // say a few normal messages without any time passing to raise pressure
         var message1 = "hi everypony";
@@ -54,7 +54,7 @@ public class SpamModuleTests
             (cfg.SpamBasePressure + Math.Round(cfg.SpamLengthPressure * message1.Length, 2)) +
             (cfg.SpamBasePressure + Math.Round(cfg.SpamLengthPressure * message2.Length, 2)) +
             (cfg.SpamBasePressure + commandLengthPenalty);
-        Assert.AreEqual($"Current Pressure for Sunny#1234: {secondPressure}", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"Current Pressure for Sunny (Sunny/2): {secondPressure}", generalChannel.Messages.Last().Content);
 
         // simulate 10 seconds of pressure decay
         DateTimeHelper.FakeUtcNow = DateTimeHelper.FakeUtcNow?.AddSeconds(10);
@@ -64,7 +64,7 @@ public class SpamModuleTests
 
         var thirdPressure = (secondPressure - (10 * (cfg.SpamBasePressure / cfg.SpamPressureDecay))) +
             (cfg.SpamBasePressure + cfg.SpamRepeatPressure + commandLengthPenalty);
-        Assert.AreEqual($"Current Pressure for Sunny#1234: {thirdPressure}", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"Current Pressure for Sunny (Sunny/2): {thirdPressure}", generalChannel.Messages.Last().Content);
 
         // let pressure fully decay back to zero
         DateTimeHelper.FakeUtcNow = DateTimeHelper.FakeUtcNow?.AddMinutes(10);
@@ -73,7 +73,7 @@ public class SpamModuleTests
         await sm.TestableGetPressureAsync(context, "");
 
         var finalPressure = cfg.SpamBasePressure + cfg.SpamRepeatPressure + commandLengthPenalty;
-        Assert.AreEqual($"Current Pressure for Sunny#1234: {finalPressure}", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"Current Pressure for Sunny (Sunny/2): {finalPressure}", generalChannel.Messages.Last().Content);
     }
 
     [TestMethod()]
@@ -102,7 +102,7 @@ public class SpamModuleTests
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".getmessages");
         await sm.TestableGetPreviousMessagesAsync(context, "");
 
-        Assert.AreEqual($"I consider the following messages from Sunny#1234 to be recent: " +
+        Assert.AreEqual($"I consider the following messages from Sunny (Sunny/2) to be recent: " +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/0 at <t:1286668800:F> (<t:1286668800:R>)" +
             $"\n*Note that these messages may not actually be recent as their age is only checked when the user sends more messages.*",
             generalChannel.Messages.Last().Content);
@@ -116,7 +116,7 @@ public class SpamModuleTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".getmessages");
         await sm.TestableGetPreviousMessagesAsync(context, "");
 
-        Assert.AreEqual($"I consider the following messages from Sunny#1234 to be recent: " +
+        Assert.AreEqual($"I consider the following messages from Sunny (Sunny/2) to be recent: " +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/0 at <t:1286668800:F> (<t:1286668800:R>)" +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/1 at <t:1286668800:F> (<t:1286668800:R>)" +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/2 at <t:1286668800:F> (<t:1286668800:R>)" +
@@ -130,7 +130,7 @@ public class SpamModuleTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".getmessages");
         await sm.TestableGetPreviousMessagesAsync(context, "");
 
-        Assert.AreEqual($"I consider the following messages from Sunny#1234 to be recent: " +
+        Assert.AreEqual($"I consider the following messages from Sunny (Sunny/2) to be recent: " +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/0 at <t:1286668800:F> (<t:1286668800:R>)" +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/1 at <t:1286668800:F> (<t:1286668800:R>)" +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/2 at <t:1286668800:F> (<t:1286668800:R>)" +
@@ -145,7 +145,7 @@ public class SpamModuleTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".getmessages");
         await sm.TestableGetPreviousMessagesAsync(context, "");
 
-        Assert.AreEqual($"I consider the following messages from Sunny#1234 to be recent: " +
+        Assert.AreEqual($"I consider the following messages from Sunny (Sunny/2) to be recent: " +
             $"\nhttps://discord.com/channels/{guild.Id}/{generalChannel.Id}/5 at <t:1286669410:F> (<t:1286669410:R>)" +
             $"\n*Note that these messages may not actually be recent as their age is only checked when the user sends more messages.*",
             generalChannel.Messages.Last().Content);
@@ -180,12 +180,12 @@ public class SpamModuleTests
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".getpressure {regularUserId}");
         await sm.TestableGetPressureAsync(context, $"{regularUserId}");
 
-        Assert.AreEqual($"Current Pressure for Zipp#1234: 0", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"Current Pressure for Zipp (Zipp/3): 0", generalChannel.Messages.Last().Content);
 
         context = await client.AddMessageAsync(guild.Id, modChat.Id, sunny.Id, $".getpressure {regularUserId}");
         await sm.TestableGetPressureAsync(context, $"{regularUserId}");
 
-        Assert.AreEqual($"Current Pressure for Zipp#1234: 0", modChat.Messages.Last().Content);
+        Assert.AreEqual($"Current Pressure for Zipp (Zipp/3): 0", modChat.Messages.Last().Content);
     }
 
 }

--- a/Izzy-MoonbotTests/Tests/TestAdapters.cs
+++ b/Izzy-MoonbotTests/Tests/TestAdapters.cs
@@ -11,7 +11,7 @@ public class TestUser : IIzzyUser
 {
     public ulong Id { get; }
     public string Username { get; }
-    public string DisplayName => Username; // TODO: implement nicknames
+    public string? GlobalName => Username;
     public bool IsBot { get; }
 
     public TestUser(string username, ulong id, bool isBot = false)
@@ -26,7 +26,9 @@ public class TestGuildUser : IIzzyGuildUser
 {
     public ulong Id { get; }
     public string Username { get; }
-    public string DisplayName => Username; // TODO: implement nicknames
+    public string? GlobalName => Username;
+    public string? Nickname => Username;
+    public string DisplayName => Username;
     public bool IsBot { get; }
 
     private readonly StubGuild _guildBackref;


### PR DESCRIPTION
Closes #409

Izzy's output most often represents a user either as a mention (which doesn't need any changes), or as `<Username>#<Discriminator> (<Id>)`. This used to produce output like `Ixrec#7992 (283037539755884554)`, but after the recent username changes it now produces `ixrec#0000 (283037539755884554)`. I've decided to change our go-to format to `<DisplayName> (<Username>/<Id>)`, thus producing `Ixrec (ixrec/283037539755884554)` instead.

I've also made `.userinfo` explicitly mention the global display name and server nickname along with everything else.

This glosses over dozens of smaller decisions I made that aren't worth trying to list exhaustively.