### PR TITLE
banner tasks/commands should post the underlying error message to Discord

### DIFF
--- a/Izzy-Moonbot/Modules/ModMiscModule.cs
+++ b/Izzy-Moonbot/Modules/ModMiscModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -818,12 +818,11 @@ public class ModMiscModule : ModuleBase<SocketCommandContext>
         {
             await DiscordHelper.SetBannerToUrlImage(cleanUrl, new SocketGuildAdapter(Context.Guild));
         }
-        catch (FlurlHttpException ex)
+        catch (Exception ex)
         {
-            var errorMsg = $"Recieved HTTP exception when executing Banner Rotation: {ex.Message}";
+            var errorMsg = $"Failed to set banner: [{ex.GetType().Name}] {ex.Message}\n{ex.StackTrace}";
             await ReplyAsync(errorMsg);
             _logger.Log(errorMsg);
-            return;
         }
         var msg = $"Set banner to <{cleanUrl}>";
 

--- a/Izzy-Moonbot/Service/ScheduleService.cs
+++ b/Izzy-Moonbot/Service/ScheduleService.cs
@@ -399,39 +399,11 @@ public class ScheduleService
                         $"Set banner to {url} for banner rotation.")
                     .Send();
             }
-            catch (FlurlHttpTimeoutException ex)
-            {
-                await _modLogging.CreateModLog(guild)
-                    .SetContent(
-                        $"Tried to change banner but the host server didn't respond fast enough, is it down? If so please run `.config BannerMode None` to avoid unnecessarily pinging Manebooru.")
-                    .SetFileLogContent(
-                        $"Tried to change banner but the host server didn't respond fast enough, is it down? If so please run `.config BannerMode None` to avoid unnecessarily pinging Manebooru.")
-                    .Send();
-                _logger.Log(
-                    $"Encountered HTTP timeout exception when trying to change banner: {ex.Message}\n{ex.StackTrace}");
-            }
-            catch (FlurlHttpException ex)
-            {
-                // Http request failure.
-                await _modLogging.CreateModLog(guild)
-                    .SetContent(
-                        $"Tried to change banner and received a {ex.StatusCode} status code when attempting to ask the host server for the image. Doing nothing.")
-                    .SetFileLogContent(
-                        $"Tried to change banner and received a {ex.StatusCode} status code when attempting to ask the host server for the image. Doing nothing.")
-                    .Send();
-                _logger.Log(
-                    $"Encountered HTTP exception when trying to change banner: {ex.Message}\n{ex.StackTrace}");
-            }
             catch (Exception ex)
             {
-                await _modLogging.CreateModLog(guild)
-                    .SetContent(
-                        $"Tried to change banner and received a general error when attempting to ask the host server for the image. Doing nothing.")
-                    .SetFileLogContent(
-                        $"Tried to change banner and received a general error when attempting to ask the host server for the image. Doing nothing.")
-                    .Send();
-                _logger.Log(
-                    $"Encountered exception when trying to change banner: {ex.Message}\n{ex.StackTrace}");
+                var msg = $"Failed to change banner: [{ex.GetType().Name}] {ex.Message}\n{ex.StackTrace}";
+                await _modLogging.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+                _logger.Log(msg);
             }
         }
         else if (_config.BannerMode == ConfigListener.BannerMode.ManebooruFeatured)
@@ -481,55 +453,11 @@ public class ScheduleService
                 else
                     _logger.Log("Can't post logs because .config LogChannel hasn't been set.");
             }
-            catch (FlurlHttpTimeoutException ex)
-            {
-                await _modLogging.CreateModLog(guild)
-                    .SetContent(
-                        $"Tried to change banner but Manebooru didn't respond fast enough, is it down? If so please run `.config BannerMode None` to avoid unnecessarily pinging Manebooru.")
-                    .SetFileLogContent(
-                        $"Tried to change banner but Manebooru didn't respond fast enough, is it down? If so please run `.config BannerMode None` to avoid unnecessarily pinging Manebooru.")
-                    .Send();
-                _logger.Log(
-                    $"Encountered HTTP timeout exception when trying to change banner: {ex.Message}\n{ex.StackTrace}");
-            }
-            catch (FlurlHttpException ex)
-            {
-                // Http request failure.
-                await _modLogging.CreateModLog(guild)
-                    .SetContent(
-                        $"Tried to change banner and received a {ex.StatusCode} status code when attempting to ask Manebooru for the featured image. Doing nothing.\n" +
-                        $"Likely causes:\n" +
-                        $"  - I sent a badly formatted request to Manebooru.\n" +
-                        $"  - Manebooru thinks I sent a badly formatted request when I didn't.\n" +
-                        $"  - Manebooru is down and Cloudflare is giving me a error page.")
-                    .SetFileLogContent(
-                        $"Tried to change banner and recieved a {ex.StatusCode} status code when attempting to ask Manebooru for the featured image. Doing nothing.\n" +
-                        $"Likely causes:\n" +
-                        $"  - I sent a badly formatted request to Manebooru.\n" +
-                        $"  - Manebooru thinks I sent a badly formatted request when I didn't.\n" +
-                        $"  - Manebooru is down and Cloudflare is giving me a error page.")
-                    .Send();
-                _logger.Log(
-                    $"Encountered HTTP exception when trying to change banner: {ex.Message}\n{ex.StackTrace}");
-            }
             catch (Exception ex)
             {
-                await _modLogging.CreateModLog(guild)
-                    .SetContent(
-                        $"Tried to change banner and received a general error when attempting to ask Manebooru for the featured image. Doing nothing.\n" +
-                        $"Likely causes:\n" +
-                        $"  - The image is too big for Discord.\n" +
-                        $"  - This server cannot have a banner.\n" +
-                        $"  - The banner rotation job is an unexpected state.")
-                    .SetFileLogContent(
-                        $"Tried to change banner and received a general error when attempting to ask Manebooru for the featured image. Doing nothing.\n" +
-                        $"Likely causes:\n" +
-                        $"  - The image is too big for Discord.\n" +
-                        $"  - This server cannot have a banner.\n" +
-                        $"  - The banner rotation job is an unexpected state.")
-                    .Send();
-                _logger.Log(
-                    $"Encountered exception when trying to change banner: {ex.Message}\n{ex.StackTrace}");
+                var msg = $"Failed to change banner to the Manebooru featured image: [{ex.GetType().Name}] {ex.Message}\n{ex.StackTrace}";
+                await _modLogging.CreateModLog(guild).SetContent(msg).SetFileLogContent(msg).Send();
+                _logger.Log(msg);
             }
         }
     }


### PR DESCRIPTION
Closes #434

Let's also stop trying to guess the cause at all, much less catch specific exceptions only to post a slightly different guess. Experience has shown that there are several kinds of "benign errors" involving banners that aren't Izzy's fault, and are best directly exposed to the user (e.g. "image too large").