### PR TITLE
Make dependabot checks monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/Izzy-MoonbotTests" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     # Prefix all commit messages with "NuGet"
     # include a list of updated dependencies
     commit-message:
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "Actions"
       include: "scope"
@@ -30,7 +30,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/Izzy-Moonbot"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     assignees:
       - "LunarNightShade"
     reviewers:


### PR DESCRIPTION
None of these updates have ever been important to us, so even weekly PRs feels like overkill when we have maybe ~0.3 developers actively working on Izzy.

(the one dependency update that did matter, Discord.NET 3.11, we did before dependabot said anything)