### PR TITLE
smart-ish witty pattern matching and multiple responses

### DIFF
--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -235,6 +235,7 @@ public class ConfigDescriber
                 "A map from message patterns to automated Izzy responses. Also known as an 'autoresponder.'" +
                     " For example, `.config Witties set \"izzy\" \"hi!\"` will make Izzy post \"hi!\" whenever any non-bot posts" +
                     " a message with \"izzy\" (in one of `WittyChannels`, at least `WittyCooldown` seconds after the last witty response).\n" +
+                "If the response contains `|`s, Izzy will treat it as multiple possible responses, and select one at random.\n" +
                 "There is no regex or wildcard syntax, but witty pattern matching is 'smart' or 'fuzzy' in the following ways:\n" +
                 " - case-insensitive: `izzy` matches `Izzy` and `IZZY`\n" +
                 " - some punctuation marks (,.'\"!) are optional: `hi, ponies!` matches `hi ponies`\n" +

--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -232,10 +232,14 @@ public class ConfigDescriber
         // Witty settings
         _config.Add("Witties",
             new ConfigItem(ConfigItemType.StringDictionary,
-                "A map from message patterns to automated Izzy responses. Also known as an 'autoresponder.'\n" +
-                "For example, `.config Witties set \"izzy\" \"that's my name!\"` will make Izzy post \"that's my name!\" whenever anyone posts a message containing \"izzy\" (or any capitalization thereof).\n" +
-                "This will only happen if the message is in one of the `WittyChannels` channels, and no witty response has been posted within the last `WittyCooldown` seconds, and the message author is not a bot.\n" +
-                "Currently, there is no special pattern matching syntax; the 'patterns' are just strings taken literally. No wildcards or regexes.",
+                "A map from message patterns to automated Izzy responses. Also known as an 'autoresponder.'" +
+                    " For example, `.config Witties set \"izzy\" \"hi!\"` will make Izzy post \"hi!\" whenever any non-bot posts" +
+                    " a message with \"izzy\" (in one of `WittyChannels`, at least `WittyCooldown` seconds after the last witty response).\n" +
+                "There is no regex or wildcard syntax, but witty pattern matching is 'smart' or 'fuzzy' in the following ways:\n" +
+                " - case-insensitive: `izzy` matches `Izzy` and `IZZY`\n" +
+                " - some punctuation marks (,.'\"!) are optional: `hi, ponies!` matches `hi ponies`\n" +
+                " - spaces are optional and allow extra spaces: `hi izzy` matches `hiizzy` and `hi    izzy`\n" +
+                " - whole 'word' matches only: `test` matches `this is a test!` but does NOT match `testy` or `attest`",
                 ConfigItemCategory.Witty));
         _config.Add("WittyChannels",
             new ConfigItem(ConfigItemType.ChannelSet,

--- a/Izzy-Moonbot/EventListeners/MessageListener.cs
+++ b/Izzy-Moonbot/EventListeners/MessageListener.cs
@@ -80,8 +80,16 @@ public class MessageListener
         // If none of the witty patterns matched, do nothing
         if (match.Key == null) return;
 
-        _logger.Log($"Posting witty response \"{match.Value}\" in {message.Channel.Name}");
-        await message.Channel.SendMessageAsync(match.Value);
+        var response = match.Value;
+        if (match.Value.Contains('|'))
+        {
+            var responses = match.Value.Split('|');
+            var responseIndex = new Random().Next(responses.Count());
+            response = responses[responseIndex];
+            _logger.Log($"Witty response contained {responses.Count()} |-delimited responses. Chose response {responseIndex} at random: \"{response}\"");
+        }
+        _logger.Log($"Posting witty response \"{response}\" in {message.Channel.Name}");
+        await message.Channel.SendMessageAsync(response);
 
         _state.LastWittyResponse = DateTimeOffset.UtcNow;
     }


### PR DESCRIPTION
more of #61

Unfortunately this can't quite be used as-is because it turns out `.config` doesn't handle quoted arguments like I thought it did, so you can't actually input patterns with spaces. But I'll fix that bug later, and then witties will be "done until feedback".