### PR TITLE
.config map set with quoted arg

### DIFF
--- a/Izzy-Moonbot/Modules/ConfigCommand.cs
+++ b/Izzy-Moonbot/Modules/ConfigCommand.cs
@@ -674,15 +674,15 @@ public class ConfigCommand
                 }
                 else if (action == "set")
                 {
-                    var key = value.Split(' ')[0].ToLower();
-                    value = value.Replace(key + " ", "");
+                    var (key, setValue) = DiscordHelper.GetArgument(value);
+                    key = key ?? "";
+                    value = setValue ?? "";
                     
                     switch (configItem.Type)
                     {
                         case ConfigItemType.StringDictionary:
                             try
                             {
-                                key = DiscordHelper.StripQuotes(key);
                                 value = DiscordHelper.StripQuotes(value);
 
                                 (string, string?, string?) result = ("", null, null);

--- a/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
@@ -724,12 +724,12 @@ public class ConfigCommandTests
         TestUtils.AssertSetsAreEqual(new HashSet<string> { ".echo glitter!" }, cfg.BoredCommands);
         Assert.AreEqual("I added the following content to the `BoredCommands` string list:\n```\n.echo glitter!\n```", generalChannel.Messages.Last().Content);
 
-        // post ".config Witties set \"izzy\" \"that's my name!\""
+        // post ".config Witties set \"hi izzy\" \"that's my name!\""
         TestUtils.AssertDictionariesAreEqual(new Dictionary<string, string>(), cfg.Witties);
-        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config Witties set \"izzy\" \"that's my name!\"");
-        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "Witties", "set \"izzy\" \"that's my name!\"");
-        TestUtils.AssertDictionariesAreEqual(new Dictionary<string, string> { { "izzy", "that's my name!" } }, cfg.Witties);
-        Assert.AreEqual("I added the following string to the `izzy` map key in the `Witties` map: `that's my name!`", generalChannel.Messages.Last().Content);
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config Witties set \"hi izzy\" \"that's my name!\"");
+        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "Witties", "set \"hi izzy\" \"that's my name!\"");
+        TestUtils.AssertDictionariesAreEqual(new Dictionary<string, string> { { "hi izzy", "that's my name!" } }, cfg.Witties);
+        Assert.AreEqual("I added the following string to the `hi izzy` map key in the `Witties` map: `that's my name!`", generalChannel.Messages.Last().Content);
 
         // post ".config WittyChannels add <#2>"
         TestUtils.AssertSetsAreEqual(new HashSet<ulong>(), cfg.WittyChannels);


### PR DESCRIPTION
While working on https://github.com/Manechat/izzy-moonbot/pull/468 I discovered this bug:

<img width="456" alt="image" src="https://github.com/Manechat/izzy-moonbot/assets/5285357/aba467e0-2ccd-4bd3-bf43-d75e52db8b49">

which I believe is a serious blocker for witties. Fortunately it's also a very easy fix now that we have good argument parsing helpers.

Closes #61