### PR TITLE
use ToUnixTimeSeconds instead of Milliseconds when printing to a Discord timestamp

### DIFF
--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -338,7 +338,7 @@ public static class DiscordHelper
         return $"Command `{context.Message.Content}` " +
             $"was run by {DisplayName(user, context.Guild)} ({user.Username}/{user.Id}) " +
             $"in #{channel.Name} (<#{channel.Id}>) " +
-            $"at {now} (<t:{now.ToUnixTimeMilliseconds()}>)";
+            $"at {now} (<t:{now.ToUnixTimeSeconds()}>)";
     }
 
     // For a GuildUser, the .DisplayName property appears to use


### PR DESCRIPTION
<img width="426" alt="image" src="https://github.com/Manechat/izzy-moonbot/assets/5285357/8ed6181b-a2e8-480e-8c49-bf96f7138aa6">
