### PR TITLE
delete the trailing slash from BooruSettings.Endpoint in all versions of appsettings.json

### DIFF
--- a/Izzy-Moonbot/Docker Compose/Dev/appsettings.Development.sample.json
+++ b/Izzy-Moonbot/Docker Compose/Dev/appsettings.Development.sample.json
@@ -6,7 +6,7 @@
     },
     "BooruSettings": {
         "Token": "<SECRET>",
-        "Endpoint": "https://manebooru.art/",
+        "Endpoint": "https://manebooru.art",
         "Version": "v1"
     },
     "DatabaseSettings": {

--- a/Izzy-Moonbot/Docker Compose/Dev/appsettings.sample.json
+++ b/Izzy-Moonbot/Docker Compose/Dev/appsettings.sample.json
@@ -6,7 +6,7 @@
     },
     "BooruSettings": {
         "Token": "<SECRET>",
-        "Endpoint": "https://manebooru.art/",
+        "Endpoint": "https://manebooru.art",
         "Version": "v1"
     }
 }

--- a/Izzy-Moonbot/appsettings.Development.sample.json
+++ b/Izzy-Moonbot/appsettings.Development.sample.json
@@ -6,7 +6,7 @@
     },
     "BooruSettings": {
         "Token": "<SECRET>",
-        "Endpoint": "https://manebooru.art/",
+        "Endpoint": "https://manebooru.art",
         "Version": "v1"
     },
     "DatabaseSettings": {

--- a/Izzy-Moonbot/appsettings.sample.json
+++ b/Izzy-Moonbot/appsettings.sample.json
@@ -6,7 +6,7 @@
     },
     "BooruSettings": {
         "Token": "<SECRET>",
-        "Endpoint": "https://manebooru.art/",
+        "Endpoint": "https://manebooru.art",
         "Version": "v1"
     }
 }


### PR DESCRIPTION
The one place where we use `Endpoint` is already adding a slash after it:

https://github.com/Manechat/izzy-moonbot/blob/40be22ad95ed8324f480f5945b162d52f1a4b761/Izzy-Moonbot/Helpers/BooruHelper.cs#L15

The double-slash was only noticed because of a spurious Manebooru failure:

<img width="495" alt="image" src="https://github.com/Manechat/izzy-moonbot/assets/5285357/9fb87f8b-1262-4afc-98b2-e29aef5f0171">

I've already manually edited the prod appsettings.json file, since that's not stored in this repo to protect secret keys.