### PR TITLE
#465 make .removequote work for users no longer in Manechat

### DIFF
--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -354,7 +354,7 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             if (quoteUser == null)
                 throw new TargetException("The user this alias referenced to cannot be found.");
 
-            await _quoteService.RemoveQuote(quoteUser, number.Value - 1);
+            await _quoteService.RemoveQuote(quoteUser.Id, number.Value - 1);
 
             await context.Channel.SendMessageAsync(
                 $"Removed quote #{number.Value} from **{quoteUser.DisplayName}** ({quoteUser.Username}).", allowedMentions: AllowedMentions.None);
@@ -368,17 +368,10 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
             return;
         }
 
-        var member = context.Guild.GetUser(userId);
-        if (member == null)
-        {
-            await context.Channel.SendMessageAsync($"Sorry, I couldn't find that user");
-            return;
-        }
-
-        var newUserQuote = await _quoteService.RemoveQuote(member, number.Value - 1);
+        await _quoteService.RemoveQuote(userId, number.Value - 1);
 
         await context.Channel.SendMessageAsync(
-            $"Removed quote #{number.Value} from **{newUserQuote.Name}**.", allowedMentions: AllowedMentions.None);
+            $"Removed quote #{number.Value} from **<@{userId}>**.", allowedMentions: AllowedMentions.None);
         return;
     }
 

--- a/Izzy-Moonbot/Service/QuoteService.cs
+++ b/Izzy-Moonbot/Service/QuoteService.cs
@@ -163,34 +163,19 @@ public class QuoteService
         return new Quote(quoteId, quoteName, content);
     }
 
-    /// <summary>
-    /// Remove a quote from a user.
-    /// </summary>
-    /// <param name="user">The user to remove the quote from.</param>
-    /// <param name="id">The id of the quote to remove.</param>
-    /// <returns>The Quote that was removed.</returns>
-    /// <exception cref="NullReferenceException">If the user doesn't have any quotes.</exception>
-    /// <exception cref="IndexOutOfRangeException">If the quote id provided doesn't exist.</exception>
-    public async Task<Quote> RemoveQuote(IIzzyUser user, int id)
+    public async Task RemoveQuote(ulong userId, int id)
     {
-        if (!_quoteStorage.Quotes.TryGetValue(user.Id.ToString(), out var quotes))
+        if (!_quoteStorage.Quotes.TryGetValue(userId.ToString(), out var quotes))
             throw new NullReferenceException("That user does not have any quotes.");
-        
+
         if (quotes.Count <= id) throw new IndexOutOfRangeException("That quote ID does not exist.");
-        
-        var quoteName = user.Username;
-        if (user is IGuildUser guildUser) quoteName = guildUser.DisplayName;
 
-        var quoteContent = quotes[id];
-        
-        _quoteStorage.Quotes[user.Id.ToString()].RemoveAt(id);
+        _quoteStorage.Quotes[userId.ToString()].RemoveAt(id);
 
-        if (_quoteStorage.Quotes[user.Id.ToString()].Count == 0)
-            _quoteStorage.Quotes.Remove(user.Id.ToString());
-        
+        if (_quoteStorage.Quotes[userId.ToString()].Count == 0)
+            _quoteStorage.Quotes.Remove(userId.ToString());
+
         await FileHelper.SaveQuoteStorageAsync(_quoteStorage);
-        
-        return new Quote(id, quoteName, quoteContent);
     }
 }
 

--- a/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
@@ -41,7 +41,7 @@ public class QuoteServiceTests
             "eat more vegetables"
         }, qs.GetQuotes(sunny.Id));
 
-        await qs.RemoveQuote(sunny, 0);
+        await qs.RemoveQuote(sunny.Id, 0);
 
         TestUtils.AssertListsAreEqual(new List<string> {
             "eat more vegetables"


### PR DESCRIPTION
Made the confirmation message after .removequote always do a user mention instead of fetching their name, since that's just easier after we stop assuming we can always get a name, and more consistent.

Internally, `QuoteService.RemoveQuote` was bending over backwards to return a `Quote` object, but no one actually used it, so I just deleted that.

Fixes #465 