### PR TITLE
better error messages when .q user N finds <N quotes for user

### DIFF
--- a/Izzy-Moonbot/Modules/QuotesModule.cs
+++ b/Izzy-Moonbot/Modules/QuotesModule.cs
@@ -137,6 +137,18 @@ public class QuotesModule : ModuleBase<SocketCommandContext>
                 return;
             }
 
+            var quoteCount = _quoteService.GetQuoteCount((ulong)userId);
+            if (quoteCount is null)
+            {
+                await context.Channel.SendMessageAsync($"<@{userId}> doesn't have any quotes", allowedMentions: AllowedMentions.None);
+                return;
+            }
+            if (number.Value > quoteCount)
+            {
+                await context.Channel.SendMessageAsync($"<@{userId}> only has {quoteCount} quote(s)", allowedMentions: AllowedMentions.None);
+                return;
+            }
+
             var quote = _quoteService.GetQuote((ulong)userId, number.Value - 1);
             if (quote == null)
             {

--- a/Izzy-Moonbot/Service/QuoteService.cs
+++ b/Izzy-Moonbot/Service/QuoteService.cs
@@ -94,6 +94,14 @@ public class QuoteService
         }).ToArray();
     }
 
+    public int? GetQuoteCount(ulong userId)
+    {
+        if (!_quoteStorage.Quotes.TryGetValue(userId.ToString(), out var quotes))
+            return null;
+
+        return quotes.Count;
+    }
+
     public string? GetQuote(ulong userId, int index)
     {
         if (!_quoteStorage.Quotes.TryGetValue(userId.ToString(), out var quotes))

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -53,7 +53,7 @@ public class QuoteModuleTests
 
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, $".quote <@{sunny.Id}> 2");
         await qm.TestableQuoteCommandAsync(context, $"<@{sunny.Id}> 2");
-        Assert.AreEqual("I couldn't find that quote, sorry!", generalChannel.Messages.Last().Content);
+        Assert.AreEqual($"<@{sunny.Id}> only has 1 quote(s)", generalChannel.Messages.Last().Content);
 
         //
 


### PR DESCRIPTION
Closes #471. For some reason in that issue I believed the user was failing to resolve at all, but in retrospect the issue was that "sweetie" found a completely different user from the Sweetie Bot we were looking for, and that other user did not have enough quotes to satisfy the request. These new error messages should make a mistake like that clear immediately.