### PR TITLE
ensure .ass during a possible raid includes all suspected raiders, even if some of them technically aren't 'recent joins' any more

### DIFF
--- a/Izzy-Moonbot/Service/RaidService.cs
+++ b/Izzy-Moonbot/Service/RaidService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
@@ -114,6 +115,7 @@ public class RaidService
             .Send();
 
         _generalStorage.CurrentRaidMode = RaidMode.Small;
+        _generalStorage.SuspectedRaiders = recentJoins.Select(j => j.Id).ToHashSet();
         await FileHelper.SaveGeneralStorageAsync(_generalStorage);
 
         if (_config.SmallRaidDecay != null)
@@ -149,6 +151,7 @@ public class RaidService
             _log.Log("Ending small raid");
 
             _generalStorage.CurrentRaidMode = RaidMode.None;
+            _generalStorage.SuspectedRaiders.Clear();
             await FileHelper.SaveGeneralStorageAsync(_generalStorage);
 
             var msg = TIME_SINCE_SMALL() + ", " + AND_ONLY_RECENT() + CONSIDER_OVER + " " + ALARMS_ACTIVE;
@@ -161,6 +164,7 @@ public class RaidService
         _log.Log("Large raid detected!");
 
         _generalStorage.CurrentRaidMode = RaidMode.Large;
+        _generalStorage.SuspectedRaiders = recentJoins.Select(j => j.Id).ToHashSet();
         await FileHelper.SaveGeneralStorageAsync(_generalStorage);
 
         var autoSilenceValueBefore = _config.AutoSilenceNewJoins;
@@ -218,6 +222,7 @@ public class RaidService
             _log.Log("Ending large raid");
 
             _generalStorage.CurrentRaidMode = RaidMode.None;
+            _generalStorage.SuspectedRaiders.Clear();
             await FileHelper.SaveGeneralStorageAsync(_generalStorage);
 
             _config.AutoSilenceNewJoins = false;

--- a/Izzy-Moonbot/Settings/GeneralStorage.cs
+++ b/Izzy-Moonbot/Settings/GeneralStorage.cs
@@ -15,7 +15,8 @@ public class GeneralStorage
         // Antiraid
         CurrentRaidMode = RaidMode.None;
         ManualRaidSilence = false;
-        
+        SuspectedRaiders = new HashSet<ulong>();
+
         // Banner management
         CurrentBooruFeaturedImage = null;
 
@@ -27,7 +28,8 @@ public class GeneralStorage
     // Antiraid
     public RaidMode CurrentRaidMode { get; set; }
     public bool ManualRaidSilence { get; set; }
-    
+    public HashSet<ulong> SuspectedRaiders { get; set; }
+
     // Banner management
     public BooruImage? CurrentBooruFeaturedImage { get; set; }
 

--- a/Izzy-MoonbotTests/Tests/FileHelperTests.cs
+++ b/Izzy-MoonbotTests/Tests/FileHelperTests.cs
@@ -110,7 +110,18 @@ public class FileHelperTests
 
         var generalStorage = JsonConvert.DeserializeObject<GeneralStorage>(testGeneralStorage);
         var serialized = JsonConvert.SerializeObject(generalStorage, Formatting.Indented).Replace("\r\n", "\n");
-        Assert.AreEqual(testGeneralStorage, serialized);
+        Assert.AreEqual("""
+            {
+              "CurrentRaidMode": 0,
+              "ManualRaidSilence": false,
+              "SuspectedRaiders": [],
+              "CurrentBooruFeaturedImage": null,
+              "LastRollTime": "2023-05-01T10:09:04.7142987Z",
+              "UsersWhoRolledToday": [
+                283037539755884554
+              ]
+            }
+            """, serialized);
     }
 
     [TestMethod()]


### PR DESCRIPTION
Closes #485 