### PR TITLE
apply the NewMemberRole on join even if we're auto-silencing the user

### DIFF
--- a/Izzy-Moonbot/Helpers/UserHelper.cs
+++ b/Izzy-Moonbot/Helpers/UserHelper.cs
@@ -75,7 +75,7 @@ public static class UserHelper
                 rolesToAddIfMissing.Add((ulong)config.MemberRole);
             }
 
-            if (config.NewMemberRole != null && config.NewMemberRole > 0 && !silencingUser && socketGuildUser.JoinedAt is not null)
+            if (config.NewMemberRole != null && config.NewMemberRole > 0 && socketGuildUser.JoinedAt is not null)
             {
                 var joinTime = socketGuildUser.JoinedAt.Value;
                 var newMemberExpiry = joinTime.AddMinutes(config.NewMemberRoleDecay);


### PR DESCRIPTION
After today's raid we left `.ass` on slightly too long, and had to manually apply New Pony to an autosilenced join. That led to the question of why this prevents New Pony application in the first place... which I have no good answer for. It probably just shouldn't prevent that.