### PR TITLE
Channel monitoring

### DIFF
--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -272,7 +272,7 @@ public class ConfigDescriber
         _config.Add("MonitoringMessageInterval",
             new ConfigItem("MonitoringMessageInterval",
                 ConfigItemType.UnsignedInteger,
-                "The interval, in seconds, after which I will allow a user to post again in the monitored channel.",
+                "The interval, in minutes, after which I will allow a user to post again in the monitored channel.",
                 ConfigItemCategory.Monitoring));
         _config.Add("MonitoringBypassRoles",
             new ConfigItem("MonitoringBypassRoles",

--- a/Izzy-Moonbot/Describers/ConfigDescriber.cs
+++ b/Izzy-Moonbot/Describers/ConfigDescriber.cs
@@ -256,6 +256,29 @@ public class ConfigDescriber
             new ConfigItem("WittyCooldown", ConfigItemType.Double,
                 "After posting a witty response, I will not respond to any witty patterns for this many seconds.",
                 ConfigItemCategory.Witty));
+
+        // Monitoring settings
+        _config.Add("MonitoringEnabled",
+            new ConfigItem(
+                "MonitoringEnabled",
+                ConfigItemType.Boolean,
+                "Whether I will monitor a specified channel and remove messages if a user has exceeded the limit of 1 message per the specified time interval.",
+                ConfigItemCategory.Monitoring));
+        _config.Add("MonitoringChannel",
+            new ConfigItem("MonitoringChannel",
+                ConfigItemType.Channel,
+                "The channel where I will monitor and potentially remove messages.",
+                ConfigItemCategory.Monitoring));
+        _config.Add("MonitoringMessageInterval",
+            new ConfigItem("MonitoringMessageInterval",
+                ConfigItemType.UnsignedInteger,
+                "The interval, in seconds, after which I will allow a user to post again in the monitored channel.",
+                ConfigItemCategory.Monitoring));
+        _config.Add("MonitoringBypassRoles",
+            new ConfigItem("MonitoringBypassRoles",
+                ConfigItemType.RoleSet,
+                "The roles I will not take action against when I detect a limit trip.",
+                ConfigItemCategory.Monitoring));
     }
 
     public List<string> GetSettableConfigItems()
@@ -307,6 +330,8 @@ public class ConfigDescriber
                 return ConfigItemCategory.Bored;
             case "witty":
                 return ConfigItemCategory.Witty;
+            case "monitoring":
+                return ConfigItemCategory.Monitoring;
             default:
                 return null;
         }
@@ -334,6 +359,8 @@ public class ConfigDescriber
                 return "Bored";
             case ConfigItemCategory.Witty:
                 return "Witty";
+            case ConfigItemCategory.Monitoring:
+                return "Monitoring";
             default:
                 return "<UNKNOWN>";
         }

--- a/Izzy-Moonbot/Modules/ConfigCommand.cs
+++ b/Izzy-Moonbot/Modules/ConfigCommand.cs
@@ -26,7 +26,7 @@ public class ConfigCommand
                 $"Run `{config.Prefix}config <category>` to list the config items in a category.\n" +
                 $"Run `{config.Prefix}config <item>` to view information about an item.\n" +
                 $"\n" +
-                $"Here are all the config categories I have: `setup`, `misc`, `banner`, `managedroles`, `filter`, `spam`, `raid`, `bored`.\n" +
+                $"Here are all the config categories I have: `setup`, `misc`, `banner`, `managedroles`, `filter`, `spam`, `raid`, `bored`, `witty`, `monitoring`.\n" +
                 $"\n" +
                 $"ℹ Use `{config.Prefix}help` to learn about Izzy's other commands.");
 

--- a/Izzy-Moonbot/Program.cs
+++ b/Izzy-Moonbot/Program.cs
@@ -84,6 +84,7 @@ public class Program
             services.AddSingleton<FilterService>();
             services.AddSingleton<ScheduleService>();
             services.AddSingleton<QuoteService>();
+            services.AddSingleton<MonitoringService>();
             services.AddSingleton(services);
             
             // EventListeners

--- a/Izzy-Moonbot/Service/MonitoringService.cs
+++ b/Izzy-Moonbot/Service/MonitoringService.cs
@@ -61,7 +61,7 @@ public class MonitoringService
         {
             // too soon, smack them
             await context.Message.DeleteAsync();
-            await context.Message.Channel.SendMessageAsync($"<@{guildUser.Id}> sorry that I had removed your post, but it hasn't been {GetReadableString(monitoringPeriod)} since your last one yet!");
+            await context.Message.Channel.SendMessageAsync($"<@{guildUser.Id}> sorry that I had to remove your post, but it hasn't been {GetReadableString(monitoringPeriod)} since your last one yet!");
         }
     }
 

--- a/Izzy-Moonbot/Service/MonitoringService.cs
+++ b/Izzy-Moonbot/Service/MonitoringService.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Izzy_Moonbot.Adapters;
+using Izzy_Moonbot.Helpers;
+using Izzy_Moonbot.Settings;
+using System.Collections.Generic;
+using System;
+
+namespace Izzy_Moonbot.Service;
+
+public class MonitoringService
+{
+    private readonly Config _config;
+    private readonly Dictionary<ulong, User> _users;
+
+    public MonitoringService(Config config, Dictionary<ulong, User> users)
+    {
+        _config = config;
+        _users = users;
+    }
+
+    public void RegisterEvents(IIzzyClient client)
+    {
+        client.MessageReceived += async (message) => await DiscordHelper.LeakOrAwaitTask(ProcessMessage(message, client));
+    }
+
+    private async Task ProcessMessage(IIzzyMessage message, IIzzyClient client)
+    {
+        if(!_config.MonitoringEnabled) return;
+        if (message.Author.Id == client.CurrentUser.Id) return; // Don't process self
+        if (message.Author.IsBot) return; // Don't process bots
+        if (!DiscordHelper.IsInGuild(message)) return; // Don't process DMs
+        if (!DiscordHelper.IsProcessableMessage(message)) return; // Not processable
+        if (message is not IIzzyUserMessage userMessage) return; // Not processable
+
+        IIzzyContext context = client.MakeContext(userMessage);
+        
+        if (!DiscordHelper.IsDefaultGuild(context)) return;
+
+        await ProcessLimitTrip(context);
+    }
+
+    private async Task ProcessLimitTrip(IIzzyContext context)
+    {
+        if (context.User is not IIzzyGuildUser guildUser) return; // Not processable
+        if (_config.MonitoringChannel != context.Channel.Id) return; // Message is in the right channel
+        if (_config.MonitoringBypassRoles.Overlaps(guildUser.Roles.Select(role => role.Id))) return; // User doesn't have bypass role
+
+        User user = _users[guildUser.Id];
+        if(user == null) return;
+
+        TimeSpan monitoringPeriod = TimeSpan.FromSeconds(_config.MonitoringMessageInterval);
+
+        if(DateTimeOffset.Now - user.LastMessageTimeInMonitoredChannel > monitoringPeriod)
+        {
+            // user has waited long enough, allow
+            user.LastMessageTimeInMonitoredChannel = DateTimeOffset.Now;
+            await FileHelper.SaveUsersAsync(_users);
+        }
+        else
+        {
+            // too soon, smack them
+            await context.Message.DeleteAsync();
+            await context.Message.Channel.SendMessageAsync($"<@{guildUser.Id}> sorry that I had removed your post, but it hasn't been {GetReadableString(monitoringPeriod)} since your last one yet!");
+        }
+    }
+
+    private static string GetReadableString(TimeSpan timeSpan)
+    {
+        List<string> timeUnits = new();
+
+        if(timeSpan.Days > 0) timeUnits.Add(PluralizeSimple(timeSpan.Days, "day"));
+        if(timeSpan.Hours > 0) timeUnits.Add(PluralizeSimple(timeSpan.Hours, "hour"));
+        if(timeSpan.Minutes > 0) timeUnits.Add(PluralizeSimple(timeSpan.Minutes, "minute"));
+        if(timeSpan.Seconds > 0) timeUnits.Add(PluralizeSimple(timeSpan.Seconds, "second"));
+
+        return string.Join(" ", timeUnits);
+    }
+
+    private static string PluralizeSimple(int amount, string noun)
+    {
+        return $"{amount} {noun}" + (amount == 1 ? "" : "s");
+    }
+}

--- a/Izzy-Moonbot/Service/MonitoringService.cs
+++ b/Izzy-Moonbot/Service/MonitoringService.cs
@@ -51,10 +51,10 @@ public class MonitoringService
 
         TimeSpan monitoringPeriod = TimeSpan.FromSeconds(_config.MonitoringMessageInterval);
 
-        if(DateTimeOffset.Now - user.LastMessageTimeInMonitoredChannel > monitoringPeriod)
+        if(context.Message.CreatedAt - user.LastMessageTimeInMonitoredChannel > monitoringPeriod)
         {
             // user has waited long enough, allow
-            user.LastMessageTimeInMonitoredChannel = DateTimeOffset.Now;
+            user.LastMessageTimeInMonitoredChannel = context.Message.CreatedAt;
             await FileHelper.SaveUsersAsync(_users);
         }
         else

--- a/Izzy-Moonbot/Service/MonitoringService.cs
+++ b/Izzy-Moonbot/Service/MonitoringService.cs
@@ -49,7 +49,7 @@ public class MonitoringService
         User user = _users[guildUser.Id];
         if(user == null) return;
 
-        TimeSpan monitoringPeriod = TimeSpan.FromSeconds(_config.MonitoringMessageInterval);
+        TimeSpan monitoringPeriod = TimeSpan.FromMinutes(_config.MonitoringMessageInterval);
 
         if(context.Message.CreatedAt - user.LastMessageTimeInMonitoredChannel > monitoringPeriod)
         {

--- a/Izzy-Moonbot/Service/MonitoringService.cs
+++ b/Izzy-Moonbot/Service/MonitoringService.cs
@@ -61,20 +61,20 @@ public class MonitoringService
         {
             // too soon, smack them
             await context.Message.DeleteAsync();
-            await context.Message.Channel.SendMessageAsync($"<@{guildUser.Id}> sorry that I had to remove your post, but it hasn't been {GetReadableString(monitoringPeriod)} since your last one yet!");
+            await context.Message.Channel.SendMessageAsync($"<@{guildUser.Id}> sorry that I had to remove your post, but it hasn't been {GetReadableTimeSpanString(monitoringPeriod)} since your last one yet!");
         }
     }
 
-    private static string GetReadableString(TimeSpan timeSpan)
+    private static string GetReadableTimeSpanString(TimeSpan timeSpan)
     {
-        List<string> timeUnits = new();
+        List<string> timeStringParts = new();
 
-        if(timeSpan.Days > 0) timeUnits.Add(PluralizeSimple(timeSpan.Days, "day"));
-        if(timeSpan.Hours > 0) timeUnits.Add(PluralizeSimple(timeSpan.Hours, "hour"));
-        if(timeSpan.Minutes > 0) timeUnits.Add(PluralizeSimple(timeSpan.Minutes, "minute"));
-        if(timeSpan.Seconds > 0) timeUnits.Add(PluralizeSimple(timeSpan.Seconds, "second"));
+        if(timeSpan.Days > 0) timeStringParts.Add(PluralizeSimple(timeSpan.Days, "day"));
+        if(timeSpan.Hours > 0) timeStringParts.Add(PluralizeSimple(timeSpan.Hours, "hour"));
+        if(timeSpan.Minutes > 0) timeStringParts.Add(PluralizeSimple(timeSpan.Minutes, "minute"));
+        if(timeSpan.Seconds > 0) timeStringParts.Add(PluralizeSimple(timeSpan.Seconds, "second"));
 
-        return string.Join(" ", timeUnits);
+        return string.Join(" ", timeStringParts);
     }
 
     private static string PluralizeSimple(int amount, string noun)

--- a/Izzy-Moonbot/Settings/Config.cs
+++ b/Izzy-Moonbot/Settings/Config.cs
@@ -83,6 +83,12 @@ public class Config
         Witties = new Dictionary<string, string>();
         WittyChannels = new HashSet<ulong>();
         WittyCooldown = 300;
+
+        // Monitoring settings
+        MonitoringEnabled = true;
+        MonitoringChannel = 0;
+        MonitoringMessageInterval = 604800; // 7 days in seconds
+        MonitoringBypassRoles = new HashSet<ulong>();
     }
 
     // Core settings
@@ -197,4 +203,10 @@ public class Config
     public Dictionary<string, string> Witties { get; set; }
     public HashSet<ulong> WittyChannels { get; set; }
     public double WittyCooldown { get; set; }
+
+    // Monitoring settings
+    public bool MonitoringEnabled { get; set; }
+    public ulong MonitoringChannel { get; set; }
+    public ulong MonitoringMessageInterval { get; set; }
+    public HashSet<ulong> MonitoringBypassRoles { get; set; }
 }

--- a/Izzy-Moonbot/Settings/Config.cs
+++ b/Izzy-Moonbot/Settings/Config.cs
@@ -87,7 +87,7 @@ public class Config
         // Monitoring settings
         MonitoringEnabled = true;
         MonitoringChannel = 0;
-        MonitoringMessageInterval = 604800; // 7 days in seconds
+        MonitoringMessageInterval = 10080; // 7 days in minutes
         MonitoringBypassRoles = new HashSet<ulong>();
     }
 

--- a/Izzy-Moonbot/Settings/User.cs
+++ b/Izzy-Moonbot/Settings/User.cs
@@ -12,6 +12,7 @@ public class User
         Joins = new List<DateTimeOffset>();
         Silenced = false;
         RolesToReapplyOnRejoin = new HashSet<ulong>();
+        LastMessageTimeInMonitoredChannel = DateTimeOffset.MinValue;
     }
 
     public string Username { get; set; }
@@ -19,6 +20,7 @@ public class User
     public List<DateTimeOffset> Joins { get; set; }
     public bool Silenced { get; set; }
     public HashSet<ulong> RolesToReapplyOnRejoin { get; set; }
+    public DateTimeOffset LastMessageTimeInMonitoredChannel { get; set; }
 }
 
 public class PreviousMessageItem

--- a/Izzy-Moonbot/Types/ConfigItem.cs
+++ b/Izzy-Moonbot/Types/ConfigItem.cs
@@ -29,7 +29,8 @@ public enum ConfigItemCategory
     Spam,
     Raid,
     Bored,
-    Witty
+    Witty,
+    Monitoring
 }
 
 public enum ConfigItemType

--- a/Izzy-Moonbot/Worker.cs
+++ b/Izzy-Moonbot/Worker.cs
@@ -44,6 +44,7 @@ namespace Izzy_Moonbot
         private readonly ConfigListener _configListener;
         private readonly UserListener _userListener;
         private readonly MessageListener _messageListener;
+        private readonly MonitoringService _monitoringService;
         private DiscordSocketClient _client;
         public bool hasProgrammingSocks = true;
         public int LaserCount = 10;
@@ -51,7 +52,7 @@ namespace Izzy_Moonbot
         public Worker(ILogger<Worker> logger, ModLoggingService modLog, IServiceCollection services, ModService modService, RaidService raidService,
             FilterService filterService, ScheduleService scheduleService, IOptions<DiscordSettings> discordSettings,
             Config config, TransientState state, Dictionary<ulong, User> users, UserListener userListener, SpamService spamService, QuoteService quoteService,
-            ConfigListener configListener, MessageListener messageListener)
+            ConfigListener configListener, MessageListener messageListener, MonitoringService monitoringService)
         {
             _logger = logger;
             _modLog = modLog;
@@ -72,6 +73,7 @@ namespace Izzy_Moonbot
             _quoteService = quoteService;
             _configListener = configListener;
             _messageListener = messageListener;
+            _monitoringService = monitoringService;
 
             var discordConfig = new DiscordSocketConfig {
                 GatewayIntents = GatewayIntents.Guilds | GatewayIntents.GuildMembers | GatewayIntents.GuildMessages | GatewayIntents.DirectMessages | GatewayIntents.MessageContent,
@@ -116,6 +118,7 @@ namespace Izzy_Moonbot
                 _raidService.RegisterEvents(clientAdapter);
                 _filterService.RegisterEvents(clientAdapter);
                 _scheduleService.RegisterEvents(clientAdapter);
+                _monitoringService.RegisterEvents(clientAdapter);
 
                 _client.LatencyUpdated += async (int old, int value) =>
                 {

--- a/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
@@ -772,7 +772,7 @@ public class ConfigCommandTests
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "post .config MonitoringEnabled false");
         await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "MonitoringEnabled", "false");
         Assert.AreEqual(cfg.MonitoringEnabled, false);
-        Assert.AreEqual("I've set `MonitoringEnabled` to the following content: false", generalChannel.Messages.Last().Content);
+        Assert.AreEqual("I've set `MonitoringEnabled` to the following content: False", generalChannel.Messages.Last().Content);
 
         // post .config MonitoringChannel <#2>
         Assert.AreEqual(cfg.MonitoringChannel, 0ul);

--- a/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
@@ -782,7 +782,7 @@ public class ConfigCommandTests
         Assert.AreEqual("I've set `MonitoringChannel` to the following content: <#2>", generalChannel.Messages.Last().Content);
 
         // post .config MonitoringMessageInterval 60
-        Assert.AreEqual(cfg.MonitoringMessageInterval, 604800ul);
+        Assert.AreEqual(cfg.MonitoringMessageInterval, 10080ul);
         context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "post .config MonitoringMessageInterval 60");
         await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "MonitoringMessageInterval", "60");
         Assert.AreEqual(cfg.MonitoringMessageInterval, 60ul);

--- a/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
@@ -767,11 +767,40 @@ public class ConfigCommandTests
         Assert.AreEqual(cfg.WittyCooldown, 50);
         Assert.AreEqual("I've set `WittyCooldown` to the following content: 50", generalChannel.Messages.Last().Content);
 
+        // post .config MonitoringEnabled false
+        Assert.AreEqual(cfg.MonitoringEnabled, true);
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "post .config MonitoringEnabled false");
+        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "MonitoringEnabled", "false");
+        Assert.AreEqual(cfg.MonitoringEnabled, false);
+        Assert.AreEqual("I've set `MonitoringEnabled` to the following content: false", generalChannel.Messages.Last().Content);
+
+        // post .config MonitoringChannel <#2>
+        Assert.AreEqual(cfg.MonitoringChannel, 0ul);
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config MonitoringChannel <#2>");
+        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "MonitoringChannel", "<#2>");
+        Assert.AreEqual(cfg.MonitoringChannel, 2ul);
+        Assert.AreEqual("I've set `MonitoringChannel` to the following content: <#2>", generalChannel.Messages.Last().Content);
+
+        // post .config MonitoringMessageInterval 60
+        Assert.AreEqual(cfg.MonitoringMessageInterval, 604800ul);
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "post .config MonitoringMessageInterval 60");
+        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "MonitoringMessageInterval", "60");
+        Assert.AreEqual(cfg.MonitoringMessageInterval, 60ul);
+        Assert.AreEqual("I've set `MonitoringMessageInterval` to the following content: 60", generalChannel.Messages.Last().Content);
+
+        // post .config MonitoringBypassRoles add <@&1>
+        TestUtils.AssertSetsAreEqual(new HashSet<ulong>(), cfg.MonitoringBypassRoles);
+        context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".config MonitoringBypassRoles add <@&1>");
+        await ConfigCommand.TestableConfigCommandAsync(context, cfg, cd, "MonitoringBypassRoles", "add <@&1>");
+        TestUtils.AssertSetsAreEqual(new HashSet<ulong> { 1ul }, cfg.MonitoringBypassRoles);
+        Assert.AreEqual($"I added the following content to the `MonitoringBypassRoles` role list:\n" +
+            $"Alicorn",
+            generalChannel.Messages.Last().Content);
 
         // Ensure we can't forget to keep this test up to date
         var configPropsCount = typeof(Config).GetProperties().Length;
 
-        Assert.AreEqual(55, configPropsCount,
+        Assert.AreEqual(59, configPropsCount,
             $"\nIf you just added or removed a config item, then this test is probably out of date");
 
         Assert.AreEqual(configPropsCount * 2, generalChannel.Messages.Count(),

--- a/Izzy-MoonbotTests/Tests/FileHelperTests.cs
+++ b/Izzy-MoonbotTests/Tests/FileHelperTests.cs
@@ -307,7 +307,7 @@ public class FileHelperTests
               "WittyCooldown": 300.0,
               "MonitoringEnabled": true,
               "MonitoringChannel": 0,
-              "MonitoringMessageInterval": 604800,
+              "MonitoringMessageInterval": 10080,
               "MonitoringBypassRoles": []
             }
             """, serialized);

--- a/Izzy-MoonbotTests/Tests/FileHelperTests.cs
+++ b/Izzy-MoonbotTests/Tests/FileHelperTests.cs
@@ -308,8 +308,8 @@ public class FileHelperTests
               "MonitoringEnabled": true,
               "MonitoringChannel": 0,
               "MonitoringMessageInterval": 604800,
-              "MonitoringBypassRoles": [],
-              }
+              "MonitoringBypassRoles": []
+            }
             """, serialized);
     }
 

--- a/Izzy-MoonbotTests/Tests/FileHelperTests.cs
+++ b/Izzy-MoonbotTests/Tests/FileHelperTests.cs
@@ -304,8 +304,12 @@ public class FileHelperTests
               "BoredCommands": [],
               "Witties": {},
               "WittyChannels": [],
-              "WittyCooldown": 300.0
-            }
+              "WittyCooldown": 300.0,
+              "MonitoringEnabled": true,
+              "MonitoringChannel": 0,
+              "MonitoringMessageInterval": 604800,
+              "MonitoringBypassRoles": [],
+              }
             """, serialized);
     }
 
@@ -346,7 +350,8 @@ public class FileHelperTests
                   "2022-05-09T13:43:12.39+00:00"
                 ],
                 "Silenced": false,
-                "RolesToReapplyOnRejoin": []
+                "RolesToReapplyOnRejoin": [],
+                "LastMessageTimeInMonitoredChannel": "0001-01-01T00:00:00+00:00"
               }
             }
             """, serialized);

--- a/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
@@ -561,6 +561,6 @@ public class MiscModuleTests
 
         Assert.AreEqual("Sorry, I was unable to find any command, category, or alias named \"100\" that you have access to." +
             "\n" +
-            "\nI also see \"100\" in the output of: `.help rollforbestpony` and `.config UnicycleInterval`", generalChannel.Messages.Last().Content);
+            "\nI also see \"100\" in the output of: `.help rollforbestpony` and `.config UnicycleInterval` and `.config MonitoringMessageInterval`", generalChannel.Messages.Last().Content);
     }
 }


### PR DESCRIPTION
Previously we've had to manually check each post in the commissions channel to see if users are following the 'once per 7 days' rule.

To automate this I've added a 'monitoring' service which checks all messages sent in a channel and removes them if it's been less than the specified time interval. The channel, interval and bypass roles can all be configured through a new 'monitoring' category.

Users get warned by Izzy if they post too early:
![image](https://github.com/Manechat/izzy-moonbot/assets/19710443/f3f90bf5-8c55-44cd-add0-9d1db93deb6b)
Closes #529

Also added the witty category to .config