### PR TITLE
Upgrade Flurl.Http from v3 to v4 by adding Flurl.Http.Newtonsoft at the same time

### DIFF
--- a/Izzy-Moonbot/Helpers/BooruHelper.cs
+++ b/Izzy-Moonbot/Helpers/BooruHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Flurl.Http;
+using Flurl.Http.Newtonsoft;
 using Izzy_Moonbot.Settings;
 using Microsoft.Extensions.Configuration;
 

--- a/Izzy-Moonbot/Izzy-Moonbot.csproj
+++ b/Izzy-Moonbot/Izzy-Moonbot.csproj
@@ -28,7 +28,8 @@
 
     <ItemGroup>
         <PackageReference Include="Discord.Net" Version="3.12.0" />
-        <PackageReference Include="Flurl.Http" Version="3.2.4" />
+        <PackageReference Include="Flurl.Http" Version="4.0.2" />
+        <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.1" />


### PR DESCRIPTION
In Flurl 3, the `receiveJson()` method has no type parameters, and returns a `Task<dynamic>`:

<img width="396" alt="image" src="https://github.com/Manechat/izzy-moonbot/assets/5285357/c837c23f-ddc9-4312-890a-6ba571722787">

But [in Fluent 4, it's `receiveJson<T>()` returning a `Task<T>`](https://flurl.dev/docs/fluent-http/), which is why [the dependabot PR failed](https://github.com/Manechat/izzy-moonbot/pull/557).

Flurl's ["Upgrading from 3.x" Guide](https://flurl.dev/docs/upgrade/) explains that this is part of a broader move away from `dynamic`, but if you still want the old behavior, you can install [Flurl.Http.Newtonsoft](https://www.nuget.org/packages/Flurl.Http.Newtonsoft/#readme-body-tab) instead.

I doubt any of us are interested in rewriting the Manebooru network request code with stricter typing on stuff we can't possibly guarantee the type of anyway, so I followed that suggestion.