### PR TITLE
upgrade to .NET 8 and C# 12

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Izzy-Moonbot/Dockerfile
+++ b/Izzy-Moonbot/Dockerfile
@@ -1,9 +1,9 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Izzy-Moonbot/Izzy-Moonbot.csproj", "Izzy-Moonbot/"]
 RUN dotnet restore "Izzy-Moonbot/Izzy-Moonbot.csproj"

--- a/Izzy-Moonbot/Helpers/BooruHelper.cs
+++ b/Izzy-Moonbot/Helpers/BooruHelper.cs
@@ -14,7 +14,7 @@ public static class BooruHelper
         var booruSettings = _getBooruSettings();
 
         var results = await $"{booruSettings.Endpoint}/api/{booruSettings.Version}/json/images/featured"
-            .WithHeader("user-agent", $"Izzy-Moonbot (Linux x86_64) Flurl.Http/3.2.4 DotNET/7.0")
+            .WithHeader("user-agent", $"Izzy-Moonbot (Linux x86_64) Flurl.Http/3.2.4 DotNET/8.0")
             .SetQueryParam("key", booruSettings.Token)
             .GetAsync()
             .ReceiveJson();

--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -315,7 +315,7 @@ public static class DiscordHelper
     public static async Task SetBannerToUrlImage(string url, IIzzyGuild guild)
     {
         Stream stream = await url
-            .WithHeader("user-agent", $"Izzy-Moonbot (Linux x86_64) Flurl.Http/3.2.4 DotNET/7.0")
+            .WithHeader("user-agent", $"Izzy-Moonbot (Linux x86_64) Flurl.Http/3.2.4 DotNET/8.0")
             .GetStreamAsync();
 
         var image = new Image(stream);

--- a/Izzy-Moonbot/Izzy-Moonbot.csproj
+++ b/Izzy-Moonbot/Izzy-Moonbot.csproj
@@ -3,7 +3,7 @@
         <UserSecretsId>dotnet-Izzy_Moonbot-C054BD3A-F4E3-4221-81C0-9AE116BDD30F</UserSecretsId>
         <RootNamespace>Izzy_Moonbot</RootNamespace>
         <Nullable>enable</Nullable>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Izzy-MoonbotTests/Izzy-Moonbot-Tests.csproj
+++ b/Izzy-MoonbotTests/Izzy-Moonbot-Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Izzy_Moonbot_Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Supersedes https://github.com/Manechat/izzy-moonbot/pull/546 and https://github.com/Manechat/izzy-moonbot/pull/547. Just like [last time](https://github.com/Manechat/izzy-moonbot/pull/360), dependabot's naive attempt to bump the .NET version was incomplete and broken. Hopefully simply copying my past self will unbreak this. The .csproj changes in particular seem like a very plausible explanation of why the dependabot PRs broke so badly on their own.