### PR TITLE
Now that we're on C# 12, use collection expressions everywhere

### DIFF
--- a/Izzy-Moonbot/Helpers/ConfigHelper.cs
+++ b/Izzy-Moonbot/Helpers/ConfigHelper.cs
@@ -687,7 +687,7 @@ public static class ConfigHelper
             {
                 try
                 {
-                    dict.Add(dictionaryKey, new HashSet<string> { value });
+                    dict.Add(dictionaryKey, [ value ]);
 
                     pinfo.SetValue(settings, dict);
                     await FileHelper.SaveConfigAsync(settings);

--- a/Izzy-Moonbot/Helpers/DiscordHelper.cs
+++ b/Izzy-Moonbot/Helpers/DiscordHelper.cs
@@ -240,11 +240,11 @@ public static class DiscordHelper
     // Where "Discord whitespace" refers to Char.IsWhiteSpace as well as the ":blank:" emoji
     public static string TrimDiscordWhitespace(string wholeString)
     {
-        var singleCharacterOrEmojiOfWhitespace = new List<string> {
+        List<string> singleCharacterOrEmojiOfWhitespace = [
             @"\s",
             @":blank:",
             @"<:blank:[0-9]+>"
-        };
+        ];
         var runOfDiscordWhitespace = $"({ string.Join("|", singleCharacterOrEmojiOfWhitespace)})+";
 
         var leadingWhitespaceRegex = new Regex($"^{runOfDiscordWhitespace}");

--- a/Izzy-Moonbot/Helpers/PaginationHelper.cs
+++ b/Izzy-Moonbot/Helpers/PaginationHelper.cs
@@ -55,7 +55,7 @@ public class PaginationHelper
             pages[pageNumber] += lineItems[i];
         }
 
-        new PaginationHelper(context, pages.ToArray(), new string[] { header, footer }, codeblock: codeblock, allowedMentions: allowedMentions);
+        new PaginationHelper(context, pages.ToArray(), [ header, footer ], codeblock: codeblock, allowedMentions: allowedMentions);
     }
 
     public PaginationHelper(SocketCommandContext context, string[] pages, string[] staticParts,

--- a/Izzy-Moonbot/Helpers/UserHelper.cs
+++ b/Izzy-Moonbot/Helpers/UserHelper.cs
@@ -121,7 +121,7 @@ public static class UserHelper
             rolesToAddIfMissing.UnionWith(userInfo.RolesToReapplyOnRejoin);
 
         if (rolesToAddIfMissing.Count == 0)
-            return new JoinRoleResult(userInfoChanged, configChanged, new HashSet<ulong> { }, newMemberRemovalJob);
+            return new JoinRoleResult(userInfoChanged, configChanged, [], newMemberRemovalJob);
 
         HashSet<ulong> existingRoleIds = socketGuildUser.Roles.Select(r => r.Id).ToHashSet();
         HashSet<ulong> rolesToActuallyAdd = rolesToAddIfMissing.Where(r => !existingRoleIds.Contains(r)).ToHashSet();

--- a/Izzy-Moonbot/Service/SpamService.cs
+++ b/Izzy-Moonbot/Service/SpamService.cs
@@ -79,7 +79,7 @@ public class SpamService
     private void calculateMessagePressureWithoutDecay(RecentMessage message, RecentMessage? previousMessage, out double pressure, out List<(double, string)> pressureBreakdown)
     {
         pressure = 0.0;
-        pressureBreakdown = new List<(double, string)> { };
+        pressureBreakdown = [];
 
         var lengthPressure = Math.Round(_config.SpamLengthPressure * message.Content.Length, 2);
         if (lengthPressure > 0)
@@ -138,7 +138,7 @@ public class SpamService
         // Unusual character pressure
 
         // If you change this list of categories, be sure to update the config item's documentation too
-        var usualCategories = new List<UnicodeCategory> {
+        List<UnicodeCategory> usualCategories = [
             UnicodeCategory.UppercaseLetter,
             UnicodeCategory.LowercaseLetter,
             UnicodeCategory.SpaceSeparator,
@@ -147,7 +147,7 @@ public class SpamService
             UnicodeCategory.ClosePunctuation,
             UnicodeCategory.OtherPunctuation,
             UnicodeCategory.FinalQuotePunctuation
-        };
+        ];
         var unusualCharactersCount = message.Content.ToCharArray().Where(c => c != '\r' && c != '\n' && !usualCategories.Contains(CharUnicodeInfo.GetUnicodeCategory(c))).Count();
         var unusualCharacterPressure = Math.Round(unusualCharactersCount * _config.SpamUnusualCharacterPressure, 2);
         if (unusualCharacterPressure > 0)
@@ -165,7 +165,7 @@ public class SpamService
         if (message.Content == _testString)
         {
             pressure = _config.SpamMaxPressure;
-            pressureBreakdown = new List<(double, string)> { (_config.SpamMaxPressure, "Test string") };
+            pressureBreakdown = [ (_config.SpamMaxPressure, "Test string") ];
         }
     }
 

--- a/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
+++ b/Izzy-MoonbotTests/Tests/ConfigCommandTests.cs
@@ -342,21 +342,21 @@ public class ConfigCommandTests
     {
         var izzyHerself = new StubGuildUser("Izzy Moonbot", 1);
         var sunny = new StubGuildUser("Sunny", 2);
-        var users = new List<StubGuildUser> { izzyHerself, sunny };
+        List<StubGuildUser> users = [ izzyHerself, sunny ];
 
         var alicorn = new TestRole("Alicorn", 1);
         var pony = new TestRole("Pony", 2);
         var newPony = new TestRole("New Pony", 3);
-        var roles = new List<TestRole> { alicorn, pony, newPony };
+        List<TestRole> roles = [ alicorn, pony, newPony ];
 
         var generalChannel = new StubChannel(1, "general");
         var modChannel = new StubChannel(2, "modchat");
         var logChannel = new StubChannel(3, "bot-logs");
         var bestPonyChannel = new StubChannel(42, "best-pony-queue");
-        var channels = new List<StubChannel> { generalChannel, modChannel, logChannel, bestPonyChannel };
+        List<StubChannel> channels = [ generalChannel, modChannel, logChannel, bestPonyChannel ];
 
         var guild = new StubGuild(1, "Maretime Bay", roles, users, channels);
-        var client = new StubClient(izzyHerself, new List<StubGuild> { guild });
+        var client = new StubClient(izzyHerself, [ guild ]);
 
         var cfg = new Config();
         var cd = new ConfigDescriber();

--- a/Izzy-MoonbotTests/Tests/FilterServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/FilterServiceTests.cs
@@ -34,7 +34,7 @@ public class FilterServiceTests
     {
         var (cfg, _, (_, sunny), _, (generalChannel, modChat, _), guild, client) = TestUtils.DefaultStubs();
         cfg.ModChannel = modChat.Id;
-        cfg.FilterWords = new HashSet<string> { "magic", "wing", "feather", "mayonnaise" };
+        cfg.FilterWords = [ "magic", "wing", "feather", "mayonnaise" ];
         SetupFilterService(cfg, guild, client, sunny);
 
         await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "this is a completely ordinary chat message");
@@ -50,8 +50,7 @@ public class FilterServiceTests
         Assert.AreEqual(1, modChat.Messages.Count);
         Assert.AreEqual($"<@&{cfg.ModRole}> Filter Violation for <@{sunny.Id}>", modChat.Messages.Last().Content);
 
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Trigger Word", "magic"),
@@ -59,7 +58,7 @@ public class FilterServiceTests
             ("What have I done in response?", ":x: - **I've deleted the offending message.**\n" +
                                               ":mute: - **I've silenced the user.**\n" +
                                               ":exclamation: - **I've pinged all moderators.**"),
-        });
+        ]);
     }
 
     [TestMethod()]
@@ -67,7 +66,7 @@ public class FilterServiceTests
     {
         var (cfg, _, (_, sunny), _, (generalChannel, modChat, _), guild, client) = TestUtils.DefaultStubs();
         cfg.ModChannel = modChat.Id;
-        cfg.FilterWords = new HashSet<string> { "magic", "wing", "feather", "mayonnaise" };
+        cfg.FilterWords = [ "magic", "wing", "feather", "mayonnaise" ];
         SetupFilterService(cfg, guild, client, sunny);
 
         Assert.AreEqual(0, modChat.Messages.Count);
@@ -77,8 +76,7 @@ public class FilterServiceTests
         Assert.AreEqual(1, modChat.Messages.Count);
         Assert.AreEqual($"<@&{cfg.ModRole}> Filter Violation for <@{sunny.Id}>", modChat.Messages.Last().Content);
 
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Trigger Word", "magic"),
@@ -86,7 +84,7 @@ public class FilterServiceTests
             ("What have I done in response?", ":x: - **I've deleted the offending message.**\n" +
                                               ":mute: - **I've silenced the user.**\n" +
                                               ":exclamation: - **I've pinged all moderators.**"),
-        });
+        ]);
 
         // The user's second filter trip earns them a timeout instead of a silence and mod ping
 
@@ -95,14 +93,13 @@ public class FilterServiceTests
         Assert.AreEqual(2, modChat.Messages.Count);
         Assert.AreEqual($" Filter Violation for <@{sunny.Id}>", modChat.Messages.Last().Content);
 
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Trigger Word", "feather"),
             ("Filtered Message", "fEatHer"),
             ("What have I done in response?", ":x: - **I've deleted the offending message.**\n" +
                                               ":stopwatch: - Since the user was already silenced, **I've given them a one-hour timeout.**"),
-        });
+        ]);
     }
 }

--- a/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/MiscModuleTests.cs
@@ -166,13 +166,12 @@ public class MiscModuleTests
         cfg.ModChannel = modChat.Id;
         var (ss, mm) = await SetupMiscModule(cfg);
 
-        guild.RulesChannel = new StubChannel(9999, "rules", new List<StubMessage>
-        {
+        guild.RulesChannel = new StubChannel(9999, "rules", [
             new StubMessage(0, "Welcome to Maretime Bay!", sunny.Id), // the non-rule message in #rules, so FirstRuleMessageId serves a purpose
             new StubMessage(1, "something about harmony", sunny.Id),
             new StubMessage(2, "\n\nfree smoothies for everypony", sunny.Id),
             new StubMessage(3, ":blank:\n:blank:\nobey the alicorns", sunny.Id),
-        });
+        ]);
         cfg.FirstRuleMessageId = 1;
 
         var context = await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, ".rule");

--- a/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteModuleTests.cs
@@ -19,7 +19,7 @@ public class QuoteModuleTests
 
         // only one quote so that the "random" selection is deterministic for now
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add(sunny.Id.ToString(), new List<string> { "gonna be my day" });
+        quotes.Quotes.Add(sunny.Id.ToString(), [ "gonna be my day" ]);
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
@@ -82,10 +82,10 @@ public class QuoteModuleTests
 
         // Initialize sunny with multiple quotes
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add(sunny.Id.ToString(), new List<string> {
+        quotes.Quotes.Add(sunny.Id.ToString(), [
             "gonna be my day",
             "We'll do our part. Hoof to heart."
-        });
+        ]);
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
@@ -107,12 +107,12 @@ public class QuoteModuleTests
         DiscordHelper.DefaultGuildId = guild.Id;
 
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add(sunny.Id.ToString(), new List<string> { "gonna be my day", "eat more vegetables" });
-        quotes.Quotes.Add(izzy.Id.ToString(), new List<string> { "let's unicycle it" });
-        quotes.Quotes.Add(pipp.Id.ToString(), new List<string> {
+        quotes.Quotes.Add(sunny.Id.ToString(), [ "gonna be my day", "eat more vegetables" ]);
+        quotes.Quotes.Add(izzy.Id.ToString(), [ "let's unicycle it" ]);
+        quotes.Quotes.Add(pipp.Id.ToString(), [
             "Heeeey pippsqueaks! <https://youtu.be/CLT4aSurqCg> Check out my latest sooong!",
             "It may looks scary but don't be afraid~ cuz nothin's what it seems at a monster par-tay! https://youtu.be/CLT4aSurqCg"
-         });
+         ]);
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
@@ -205,7 +205,7 @@ public class QuoteModuleTests
 
         // Test with a quote from a user id that is no longer in our guild
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add("1234", new List<string> { "minty was here" });
+        quotes.Quotes.Add("1234", [ "minty was here" ]);
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
@@ -235,7 +235,7 @@ public class QuoteModuleTests
         DiscordHelper.DefaultGuildId = guild.Id;
 
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add(sunny.Id.ToString(), new List<string> { "gonna be my day", "gonna be my day" });
+        quotes.Quotes.Add(sunny.Id.ToString(), [ "gonna be my day", "gonna be my day" ]);
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
@@ -268,7 +268,7 @@ public class QuoteModuleTests
         DiscordHelper.DefaultGuildId = guild.Id;
 
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add(sunny.Id.ToString(), new List<string> { "gonna be my day" });
+        quotes.Quotes.Add(sunny.Id.ToString(), [ "gonna be my day" ]);
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);
@@ -280,9 +280,9 @@ public class QuoteModuleTests
         await qm.TestableAddQuoteCommandAsync(context, "");
 
         Assert.AreEqual("You need to tell me the user you want to add the quote to, and the content of the quote.", generalChannel.Messages.Last().Content);
-        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
+        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], [
             "gonna be my day"
-        });
+        ]);
 
         //
 
@@ -292,10 +292,10 @@ public class QuoteModuleTests
         Assert.AreEqual($"Added quote #2 to **{sunny.GlobalName}**:\n" +
             "\n" +
             ">>> eat more vegetables", generalChannel.Messages.Last().Content);
-        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
+        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], [
             "gonna be my day",
             "eat more vegetables"
-        });
+        ]);
 
         //
 
@@ -321,10 +321,10 @@ public class QuoteModuleTests
         await qm.TestableRemoveQuoteCommandAsync(context, "");
 
         Assert.AreEqual("You need to tell me the user you want to remove the quote from, and the quote number to remove.", generalChannel.Messages.Last().Content);
-        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
+        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], [
             "gonna be my day",
             "eat more vegetables"
-        });
+        ]);
 
         //
 
@@ -332,9 +332,9 @@ public class QuoteModuleTests
         await qm.TestableRemoveQuoteCommandAsync(context, $"<@{sunny.Id}> 1");
 
         Assert.AreEqual($"Removed quote #1 from **<@{sunny.Id}>**.", generalChannel.Messages.Last().Content);
-        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], new List<string> {
+        TestUtils.AssertListsAreEqual(quotes.Quotes[sunny.Id.ToString()], [
             "eat more vegetables"
-        });
+        ]);
     }
 
     // Regression test: This used to incorrectly produce "Sorry, I couldn't find that user",
@@ -350,7 +350,7 @@ public class QuoteModuleTests
         // Celestia hasn't been seen since G4
         var celestiaId = 7;
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add(celestiaId.ToString(), new List<string> { "my little ponies" });
+        quotes.Quotes.Add(celestiaId.ToString(), [ "my little ponies" ]);
 
         var userinfo = new Dictionary<ulong, User>();
         var qs = new QuoteService(quotes, userinfo);

--- a/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/QuoteServiceTests.cs
@@ -16,7 +16,7 @@ public class QuoteServiceTests
 
         // only one quote so that the "random" selection is deterministic for now
         var quotes = new QuoteStorage();
-        quotes.Quotes.Add(sunny.Id.ToString(), new List<string> { "gonna be my day" });
+        quotes.Quotes.Add(sunny.Id.ToString(), [ "gonna be my day" ]);
 
         var users = new Dictionary<ulong, User>();
         var s = new User(); s.Username = "Sunny Starscout"; users.Add(1, s);

--- a/Izzy-MoonbotTests/Tests/SpamServiceTests.cs
+++ b/Izzy-MoonbotTests/Tests/SpamServiceTests.cs
@@ -52,13 +52,12 @@ public class SpamServiceTests
 
         Assert.AreEqual(1, modChat.Messages.Count);
         Assert.AreEqual("<@&0> I've silenced <@2> for spamming and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Silenced User", "<@2> (`2`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 60, exceeding 60"),
             ("Breakdown of last message", "**Test string**"),
-        });
+        ]);
     }
 
     [TestMethod()]
@@ -94,13 +93,12 @@ public class SpamServiceTests
         Assert.AreEqual(1, modChat.Messages.Count);
 
         Assert.AreEqual($"<@&0> I've silenced <@{sunny.Id}> for spamming and deleted 6 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Silenced User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 50 to 60, exceeding 60"),
             ("Breakdown of last message", "**Base: 10**"),
-        });
+        ]);
 
         // since Izzy tries to avoid duplicate alarms, we have to post one ordinary message
         // to let pressure fall back below 60 before trying to raise it again
@@ -122,13 +120,12 @@ public class SpamServiceTests
 
         Assert.AreEqual(2, modChat.Messages.Count);
         Assert.AreEqual($"I've given <@{sunny.Id}> a one-hour timeout for spamming after being silenced and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Timeout User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 60, exceeding 60"),
             ("Breakdown of last message", $"**Lines: 50 ≈ 25 line breaks × 2**\nBase: 10"),
-        });
+        ]);
 
         DateTimeHelper.FakeUtcNow = DateTimeHelper.FakeUtcNow?.AddHours(1);
         await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "sorry");
@@ -149,13 +146,12 @@ public class SpamServiceTests
 
         Assert.AreEqual(3, modChat.Messages.Count);
         Assert.AreEqual($"I've given <@{sunny.Id}> a one-hour timeout for spamming after being silenced and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Timeout User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 68.4, exceeding 60"),
             ("Breakdown of last message", $"**Length: 58.4 ≈ 584 characters × 0.1**\nBase: 10"),
-        });
+        ]);
 
         DateTimeHelper.FakeUtcNow = DateTimeHelper.FakeUtcNow?.AddHours(1);
         await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "sorry");
@@ -172,13 +168,12 @@ public class SpamServiceTests
 
         Assert.AreEqual(4, modChat.Messages.Count);
         Assert.AreEqual($"I've given <@{sunny.Id}> a one-hour timeout for spamming after being silenced and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Timeout User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 60, exceeding 60"),
             ("Breakdown of last message", $"**Mentions: 50 ≈ 20 mentions × 2.5**\nBase: 10"),
-        });
+        ]);
 
         DateTimeHelper.FakeUtcNow = DateTimeHelper.FakeUtcNow?.AddHours(1);
         await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "sorry");
@@ -201,13 +196,12 @@ public class SpamServiceTests
 
         Assert.AreEqual(5, modChat.Messages.Count);
         Assert.AreEqual($"I've given <@{sunny.Id}> a one-hour timeout for spamming after being silenced and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Timeout User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 68.1, exceeding 60"),
             ("Breakdown of last message", $"**Embeds: 58.1 ≈ 7 embeds × 8.3**\nBase: 10"),
-        });
+        ]);
 
         DateTimeHelper.FakeUtcNow = DateTimeHelper.FakeUtcNow?.AddHours(1);
         await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "sorry");
@@ -225,13 +219,12 @@ public class SpamServiceTests
 
         Assert.AreEqual(6, modChat.Messages.Count);
         Assert.AreEqual($"I've given <@{sunny.Id}> a one-hour timeout for spamming after being silenced and deleted 3 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Timeout User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 40 to 70, exceeding 60"),
             ("Breakdown of last message", $"**Repeat of Previous Message: 20**\nBase: 10"),
-        });
+        ]);
 
         DateTimeHelper.FakeUtcNow = DateTimeHelper.FakeUtcNow?.AddHours(1);
         await client.AddMessageAsync(guild.Id, generalChannel.Id, sunny.Id, "sorry");
@@ -255,13 +248,12 @@ public class SpamServiceTests
 
         Assert.AreEqual(7, modChat.Messages.Count);
         Assert.AreEqual($"I've given <@{sunny.Id}> a one-hour timeout for spamming after being silenced and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Timeout User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 64, exceeding 60"),
             ("Breakdown of last message", $"**Unusual Characters: 54 ≈ 540 unusual characters × 0.1**\nBase: 10"),
-        });
+        ]);
     }
 
     [TestMethod()]
@@ -287,8 +279,7 @@ public class SpamServiceTests
         Assert.AreEqual(1, modChat.Messages.Count);
 
         Assert.AreEqual($"<@&0> I've silenced <@{sunny.Id}> for spamming and deleted 2 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Silenced User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 24.8 to 77.89999999999999, exceeding 60"),
@@ -300,7 +291,7 @@ public class SpamServiceTests
                 $"Length: 5 ≈ 50 characters × 0.1\n" +
                 $"Lines: 2 ≈ 1 line breaks × 2\n" +
                 $"Unusual Characters: 0.3 ≈ 6 unusual characters × 0.05"),
-        });
+        ]);
     }
 
     [TestMethod()]
@@ -338,8 +329,7 @@ public class SpamServiceTests
 
         Assert.AreEqual(1, modChat.Messages.Count);
         Assert.AreEqual($"<@&0> I've silenced <@{sunny.Id}> for spamming and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Silenced User", $"<@{sunny.Id}> (`{sunny.Id}`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 69.55000000000001, exceeding 60"),
@@ -348,7 +338,7 @@ public class SpamServiceTests
                 $"Unusual Characters: 14.85 ≈ 297 unusual characters × 0.05\n" +
                 $"Base: 10\n" +
                 $"Length: 2.7 ≈ 432 characters × 0.00625"),
-        });
+        ]);
     }
 
     [TestMethod()]
@@ -365,13 +355,12 @@ public class SpamServiceTests
         Assert.AreEqual(0, generalChannel.Messages.Count);
         Assert.AreEqual(1, modChat.Messages.Count);
         Assert.AreEqual("<@&0> I've silenced <@2> for spamming and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Silenced User", "<@2> (`2`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 60, exceeding 60"),
             ("Breakdown of last message", "**Test string**"),
-        });
+        ]);
 
         // Pretend we had a moon talk and let them back in
         users[sunny.Id].Silenced = false;
@@ -381,14 +370,13 @@ public class SpamServiceTests
         Assert.AreEqual(0, generalChannel.Messages.Count);
         Assert.AreEqual(2, modChat.Messages.Count);
         Assert.AreEqual("<@&0> I've silenced <@2> for spamming and deleted 1 of their message(s)", modChat.Messages.Last().Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages.Last().Embeds[0].Fields, [
             ("Silenced User", "<@2> (`2`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             // since no fake time has passed, the second spam trip says "60 to 120"
             ("Pressure", "This user's last message raised their pressure from 60 to 120, exceeding 60"),
             ("Breakdown of last message", "**Test string**"),
-        });
+        ]);
     }
 
     [TestMethod()]
@@ -409,21 +397,19 @@ public class SpamServiceTests
         Assert.AreEqual(0, generalChannel.Messages.Count);
         Assert.AreEqual(2, modChat.Messages.Count);
         Assert.AreEqual("<@&0> I've silenced <@2> for spamming and deleted 1 of their message(s)", modChat.Messages[0].Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages[0].Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages[0].Embeds[0].Fields, [
             ("Silenced User", "<@2> (`2`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 60, exceeding 60"),
             ("Breakdown of last message", "**Test string**"),
-        });
+        ]);
         Assert.AreEqual("<@&0> I've silenced <@3> for spamming and deleted 1 of their message(s)", modChat.Messages[1].Content);
-        TestUtils.AssertEmbedFieldsAre(modChat.Messages[1].Embeds[0].Fields, new List<(string, string)>
-        {
+        TestUtils.AssertEmbedFieldsAre(modChat.Messages[1].Embeds[0].Fields, [
             ("Silenced User", "<@3> (`3`)"),
             ("Channel", $"<#{generalChannel.Id}>"),
             ("Pressure", "This user's last message raised their pressure from 0 to 60, exceeding 60"),
             ("Breakdown of last message", "**Test string**"),
-        });
+        ]);
     }
 
 }

--- a/Izzy-MoonbotTests/Tests/TestAdapters.cs
+++ b/Izzy-MoonbotTests/Tests/TestAdapters.cs
@@ -73,7 +73,7 @@ public class TestGuildUser : IIzzyGuildUser
         if (ur.ContainsKey(Id))
             ur[Id].Add(roleId);
         else
-            ur[Id] = new List<ulong> { roleId };
+            ur[Id] = [ roleId ];
     }
     public async Task AddRolesAsync(IEnumerable<ulong> roles, RequestOptions? _requestOptions)
     {
@@ -705,7 +705,7 @@ public class StubClient : IIzzyClient
         if (DirectMessages.ContainsKey(userId))
             DirectMessages[userId].Add(dm);
         else
-            DirectMessages[userId] = new List<StubMessage> { dm };
+            DirectMessages[userId] = [ dm ];
     }
 
     public async Task JoinUser(string username, ulong userId, StubGuild stubGuild)

--- a/Izzy-MoonbotTests/Tests/TestUtils.cs
+++ b/Izzy-MoonbotTests/Tests/TestUtils.cs
@@ -24,20 +24,20 @@ public static class TestUtils
         var users = new List<StubGuildUser> { izzyHerself, sunny, zipp, pipp, hitch };
 
         var alicorn = new TestRole("Alicorn", 1);
-        var roles = new List<TestRole> { alicorn, new TestRole("Pegasus", 2) };
+        List<TestRole> roles = [ alicorn, new TestRole("Pegasus", 2) ];
 
         // because user ids are also Direct Message channel ids, regular channels must have different ids
         var generalChannel = new StubChannel(1001, "general");
         var modChat = new StubChannel(1002, "modchat");
         var logChat = new StubChannel(1003, "botlogs");
-        var channels = new List<StubChannel> { generalChannel, modChat, logChat };
+        List<StubChannel> channels = [ generalChannel, modChat, logChat ];
 
         var guild = new StubGuild(1, "Maretime Bay", roles, users, channels);
-        guild.UserRoles.Add(sunny.Id, new List<ulong> { alicorn.Id });
-        guild.UserRoles.Add(izzyHerself.Id, new List<ulong> { alicorn.Id }); // bots are honorary alicorns
+        guild.UserRoles.Add(sunny.Id, [ alicorn.Id ]);
+        guild.UserRoles.Add(izzyHerself.Id, [ alicorn.Id ]); // bots are honorary alicorns
         guild.ChannelAccessRole.Add(modChat.Id, alicorn.Id);
 
-        var client = new StubClient(izzyHerself, new List<StubGuild> { guild });
+        var client = new StubClient(izzyHerself, [ guild ]);
 
         var cfg = new Config();
         var cd = new ConfigDescriber();


### PR DESCRIPTION
Out of all the new features in C# 12, this is the only one that jumped out as useful that also worked when I tried it. The spread operator _seemed_ cool, but it turns out its inference/defaulting is too limited to be usable for us.