### PR TITLE
Unbreak tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,8 +4,8 @@
 name: .NET Tests
 
 on:
-  #push:
-  #  branches: [ "mane" ]
+  push:
+    branches: [ "mane" ]
   pull_request:
     branches: [ "mane" ]
     # Don't run checks on things non-code related. Add additional ignores below.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,6 +31,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build -c Release --no-restore
+      run: dotnet build -c Debug --no-restore
     - name: Test
-      run: dotnet test -c Release --no-build --verbosity normal
+      run: dotnet test -c Debug --no-build --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -354,7 +354,7 @@ botsettings/
 devsettings/
 
 # User Secrets
-**/appsettings*.json*
+**/appsettings.json*
 !appsettings*sample.json
 **/*.env*
 !*example.env

--- a/Izzy-Moonbot/appsettings.Development.json
+++ b/Izzy-Moonbot/appsettings.Development.json
@@ -1,0 +1,19 @@
+{
+    "DiscordSettings": {
+        "Token": "<SECRET>",
+        "DevUsers": [
+            221742476153716736,
+            186730180872634368,
+            493845599469174794,
+            283037539755884554,
+            189069518016872448,
+            245197038231355393
+        ],
+        "DefaultGuild": 901786293531447308
+    },
+    "BooruSettings": {
+        "Token": "<SECRET>",
+        "Endpoint": "https://manebooru.art",
+        "Version": "v1"
+    }
+}

--- a/Izzy-MoonbotTests/Tests/TestUtils.cs
+++ b/Izzy-MoonbotTests/Tests/TestUtils.cs
@@ -2,6 +2,7 @@
 using Discord;
 using Izzy_Moonbot.Adapters;
 using Izzy_Moonbot.Describers;
+using Izzy_Moonbot.Helpers;
 using Izzy_Moonbot.Settings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -24,7 +25,7 @@ public static class TestUtils
         var users = new List<StubGuildUser> { izzyHerself, sunny, zipp, pipp, hitch };
 
         var alicorn = new TestRole("Alicorn", 1);
-        List<TestRole> roles = [ alicorn, new TestRole("Pegasus", 2) ];
+        List<TestRole> roles = [ alicorn, new TestRole("Pegasus", 2), new TestRole("Tartarus", DiscordHelper.TartarusRoleId)];
 
         // because user ids are also Direct Message channel ids, regular channels must have different ids
         var generalChannel = new StubChannel(1001, "general");


### PR DESCRIPTION
Izzy's unit tests have been broken since the ZJR migration (see #612 #103 ), because that involved redefining "silencing" from the removal of a member role to the addition of a welcome/Tartarus role. The unit tests which auto-silenced a user had not defined a welcome/Tartarus role, so they failed with a very cryptic error that boiled down to "somehow user X in guild Y has role Z even though guild Y doesn't have a role Z in your mock guilds". Specifically, https://github.com/Manechat/izzy-moonbot/commit/ccf67b645d04474e5c3ce100623b6912a6f303fe is where tests broke for real, according to my local git bisecting.

I did not realize this until merging a bunch of dependabot PRs today, because all this time I thought we were running tests on every new main commit (after a PR merge, or without a PR at all). It turns out we only _build_ new main commits, and _tests_ only get run on PRs. So I'm also changing the test run workflow to apply to main commits without a PR.